### PR TITLE
fix: use "missing" in CIStatus instead of None

### DIFF
--- a/queueboard/ci_status.py
+++ b/queueboard/ci_status.py
@@ -12,7 +12,7 @@ class CIStatus(StrEnum):
     # CI is currently running
     Running = "running"
     # Missing data.
-    Missing = None
+    Missing = "missing"
 
     @staticmethod
     def from_string(s: str):


### PR DESCRIPTION
see e.g. failures in https://github.com/leanprover-community/queueboard/actions/runs/17935572347/job/51001037239