### PR TITLE
fix: make imports absolute

### DIFF
--- a/src/queueboard/check_data_integrity.py
+++ b/src/queueboard/check_data_integrity.py
@@ -17,10 +17,10 @@ from typing import List, NamedTuple, Tuple
 
 from dateutil import parser
 
-from ci_status import CIStatus
-from compute_dashboard_prs import AggregatePRInfo, infer_pr_url, Label
-from dashboard_data import parse_aggregate_file
-from util import eprint, parse_json_file
+from queueboard.ci_status import CIStatus
+from queueboard.compute_dashboard_prs import AggregatePRInfo, infer_pr_url, Label
+from queueboard.dashboard_data import parse_aggregate_file
+from queueboard.util import eprint, parse_json_file
 
 # Read the input JSON files, return a dictionary mapping each PR number
 # to the (current) last update data github provides.

--- a/src/queueboard/classify_pr_state.py
+++ b/src/queueboard/classify_pr_state.py
@@ -10,7 +10,7 @@ from typing import List, NamedTuple
 
 from dateutil import tz
 
-from ci_status import CIStatus
+from queueboard.ci_status import CIStatus
 
 
 # The different kinds of PR labels we care about.

--- a/src/queueboard/compute_dashboard_prs.py
+++ b/src/queueboard/compute_dashboard_prs.py
@@ -12,11 +12,11 @@ import sys
 from dateutil import parser, relativedelta
 from typing import Dict, List, NamedTuple, OrderedDict, Tuple, Any
 
-from ci_status import CIStatus
-from classify_pr_state import (PRState, PRStatus,
+from queueboard.ci_status import CIStatus
+from queueboard.classify_pr_state import (PRState, PRStatus,
                                determine_PR_status, label_categorisation_rules)
-from mathlib_dashboards import Dashboard, getIdTitle
-from util import my_assert_eq, timedelta_tryParse, relativedelta_tryParse
+from queueboard.mathlib_dashboards import Dashboard, getIdTitle
+from queueboard.util import my_assert_eq, timedelta_tryParse, relativedelta_tryParse
 
 
 # The following structures are completely project-agnostic.

--- a/src/queueboard/dashboard.py
+++ b/src/queueboard/dashboard.py
@@ -11,12 +11,12 @@ from typing import List, NamedTuple, Tuple
 
 from dateutil import parser, relativedelta, tz
 
-from ci_status import CIStatus
-from classify_pr_state import PRStatus
-from compute_dashboard_prs import (AggregatePRInfo, BasicPRInformation, Label, DataStatus, load_from_json_file,
+from queueboard.ci_status import CIStatus
+from queueboard.classify_pr_state import PRStatus
+from queueboard.compute_dashboard_prs import (AggregatePRInfo, BasicPRInformation, Label, DataStatus, load_from_json_file,
     infer_pr_url, link_to, gather_pr_statistics)
-from mathlib_dashboards import Dashboard, short_description, long_description, getIdTitle, getTableId
-from util import format_delta
+from queueboard.mathlib_dashboards import Dashboard, short_description, long_description, getIdTitle, getTableId
+from queueboard.util import format_delta
 
 
 ### Helper methods: writing HTML code for various parts of the generated webpage ###

--- a/src/queueboard/dashboard_data.py
+++ b/src/queueboard/dashboard_data.py
@@ -3,9 +3,9 @@ from os import path, makedirs
 import sys
 from random import shuffle
 from typing import List, NamedTuple, Dict
-from ci_status import CIStatus
-from mathlib_dashboards import Dashboard
-from compute_dashboard_prs import (AggregatePRInfo, BasicPRInformation, dump_to_json_file,
+from queueboard.ci_status import CIStatus
+from queueboard.mathlib_dashboards import Dashboard
+from queueboard.compute_dashboard_prs import (AggregatePRInfo, BasicPRInformation, dump_to_json_file,
     PLACEHOLDER_AGGREGATE_INFO, compute_pr_statusses, determine_pr_dashboards, parse_aggregate_file, _extract_prs)
 
 ### Reading the input files passed to this script ###
@@ -162,7 +162,7 @@ def main() -> None:
     # NB. These 50 PRs include any PRs without any suggested reviewer (say, because an area has not enough
     # reviewers or everybody is too busy) --- so in practice, fewer reviewers may be actually assigned.
     # XXX: importing this at the beginning leads to a circular import; importing it here seems to work.
-    from suggest_reviewer import read_reviewer_info, collect_assignment_statistics, suggest_reviewers_many
+    from queueboard.suggest_reviewer import read_reviewer_info, collect_assignment_statistics, suggest_reviewers_many
     reviewer_info = read_reviewer_info()
     assignment_stats = collect_assignment_statistics(aggregate_info)
     all_stale_unassigned : List[int] = [pr.number for pr in prs_to_list[Dashboard.QueueStaleUnassigned]]

--- a/src/queueboard/generate_assigment_page.py
+++ b/src/queueboard/generate_assigment_page.py
@@ -12,9 +12,9 @@ import glob
 from os import path
 from typing import List
 
-from ci_status import CIStatus
-from dashboard_data import determine_pr_dashboards, parse_aggregate_file
-from dashboard import (
+from queueboard.ci_status import CIStatus
+from queueboard.dashboard_data import determine_pr_dashboards, parse_aggregate_file
+from queueboard.dashboard import (
     AggregatePRInfo,
     BasicPRInformation,
     Dashboard,
@@ -30,7 +30,7 @@ from dashboard import (
     write_webpage,
 )
 
-from suggest_reviewer import (
+from queueboard.suggest_reviewer import (
   read_reviewer_info,
   suggest_reviewers,
   collect_assignment_statistics,

--- a/src/queueboard/process.py
+++ b/src/queueboard/process.py
@@ -16,9 +16,9 @@ from datetime import datetime, timezone
 from os import listdir, path
 from typing import List, Tuple
 
-from classify_pr_state import PRStatus
-from state_evolution import first_time_on_queue, last_status_update, total_queue_time
-from util import eprint, parse_json_file, relativedelta_tryParse, timedelta_tostr
+from queueboard.classify_pr_state import PRStatus
+from queueboard.state_evolution import first_time_on_queue, last_status_update, total_queue_time
+from queueboard.util import eprint, parse_json_file, relativedelta_tryParse, timedelta_tostr
 
 
 # Determine a PR's CI status: the return value is one of "pass", "fail", "fail-inessential" and "running".

--- a/src/queueboard/state_evolution.py
+++ b/src/queueboard/state_evolution.py
@@ -46,9 +46,9 @@ from typing import List, NamedTuple, Tuple
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
-from ci_status import CIStatus
-from classify_pr_state import (PRState, PRStatus, canonicalise_label, determine_PR_status, label_categorisation_rules)
-from util import format_delta
+from queueboard.ci_status import CIStatus
+from queueboard.classify_pr_state import (PRState, PRStatus, canonicalise_label, determine_PR_status, label_categorisation_rules)
+from queueboard.util import format_delta
 
 
 class LabelAdded(NamedTuple):

--- a/src/queueboard/suggest_reviewer.py
+++ b/src/queueboard/suggest_reviewer.py
@@ -9,15 +9,15 @@ This may take the current number of pull requests assigned to each reviewer into
 import json
 import sys
 from typing import List, NamedTuple, Tuple
-from classify_pr_state import PRState, PRStatus, LabelKind, determine_PR_status, label_categorisation_rules
-from compute_dashboard_prs import LastStatusChange, DataStatus
+from queueboard.classify_pr_state import PRState, PRStatus, LabelKind, determine_PR_status, label_categorisation_rules
+from queueboard.compute_dashboard_prs import LastStatusChange, DataStatus
 
 from datetime import datetime
 from os import path
 
 from dateutil import parser, tz
 
-from dashboard import (
+from queueboard.dashboard import (
     AggregatePRInfo,
     user_link,
 )

--- a/src/queueboard/test_state_evolution.py
+++ b/src/queueboard/test_state_evolution.py
@@ -4,9 +4,9 @@
 Unit test for the code in `state_evolution.py`: all of these are very mathlib-specific, hence extracted into a separate file.
 """
 
-from ci_status import CIStatus
-from classify_pr_state import LabelKind
-from state_evolution import PRState, PRStatus, Event, Metadata, total_queue_time_inner, determine_state_changes, first_on_queue_inner, last_status_update_inner
+from queueboard.ci_status import CIStatus
+from queueboard.classify_pr_state import LabelKind
+from queueboard.state_evolution import PRState, PRStatus, Event, Metadata, total_queue_time_inner, determine_state_changes, first_on_queue_inner, last_status_update_inner
 
 from dateutil.relativedelta import relativedelta
 from dateutil import tz


### PR DESCRIPTION
This is required now that the code lives in a Python package.

https://github.com/leanprover-community/queueboard/pull/124 will then make the queueboard workflows install the python package and run the scripts from the package rather than copying them around.