### PR TITLE
fix(lint): resolve all ruff errors and enforce check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           uv venv
           uv pip install -e .
 
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
       - name: Run Zulip prefs frontend tests
         working-directory: qb_site/zulip_bot/frontend
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ Notes
 
 ## Coding Style & Naming Conventions
 - Use four-space indentation, explicit imports, and `snake_case` for modules/functions, `PascalCase` for classes, `SCREAMING_SNAKE_CASE` for settings.
-- Treat `ruff` as the source of truth; prefer `ruff --fix` or `uv run ruff format .` for autofixes before committing.
-- Always format files before sending for review using: `uv run ruff format .`.
+- Treat `ruff` as the source of truth. **Before every commit**, both of the following must pass with no errors:
+  - `uv run ruff check .` — zero lint errors required; use `--fix` to auto-resolve what ruff can
+  - `uv run ruff format .` — apply canonical formatting (or `--check` to verify without writing)
 - Add type hints on new public functions, especially in Django services; reuse helpers from `queueboard.util` instead of duplicating logic.
 
 ## Testing Guidelines

--- a/qb_site/analyzer/management/commands/plan_ci_backfill.py
+++ b/qb_site/analyzer/management/commands/plan_ci_backfill.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
 from core.models import Repository
-from syncer.models import PullRequest
 from analyzer.services.ci_backfill import plan_missing_ci_shas, enqueue_ci_by_shas
 
 

--- a/qb_site/analyzer/services/ci_backfill.py
+++ b/qb_site/analyzer/services/ci_backfill.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence
 
 from core.models import Repository
 from syncer.models import PullRequest

--- a/qb_site/analyzer/services/reviewer_opt_out_backfill.py
+++ b/qb_site/analyzer/services/reviewer_opt_out_backfill.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from dataclasses import dataclass
 
 from django.db.models import Max

--- a/qb_site/api/tests/test_queueboard_snapshot.py
+++ b/qb_site/api/tests/test_queueboard_snapshot.py
@@ -68,7 +68,7 @@ class QueueboardSnapshotViewTests(TestCase):
 
     def test_stale_snapshot_triggers_refresh_but_returns_payload(self):
         stale_time = timezone.now() - timedelta(hours=1)
-        snap = self._make_snapshot(expires_at=stale_time - timedelta(minutes=5), generated_at=stale_time)
+        self._make_snapshot(expires_at=stale_time - timedelta(minutes=5), generated_at=stale_time)
 
         with patch("api.views.queueboard_snapshot.build_queueboard_snapshot.delay") as mock_delay:
             mock_delay.return_value.id = "task456"

--- a/qb_site/core/utils/db.py
+++ b/qb_site/core/utils/db.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Tuple
 
 from django.db import IntegrityError, models, transaction
 

--- a/qb_site/syncer/services/rate_budget.py
+++ b/qb_site/syncer/services/rate_budget.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """
 Rate budget coordination helpers using Redis.
 
@@ -46,7 +44,9 @@ Implementation notes
 - Continuation schedules are debounced per repo+resetAt via SETNX with TTL.
 """
 
-from datetime import datetime, timedelta, timezone
+from __future__ import annotations
+
+from datetime import datetime, timezone
 import hashlib
 import json
 import random

--- a/qb_site/syncer/services/sub/pull_request_sync.py
+++ b/qb_site/syncer/services/sub/pull_request_sync.py
@@ -7,7 +7,6 @@ from dateutil import parser as dtparser
 from django.utils import timezone
 
 from core.models.repository import Repository
-from core.models.user import User
 from core.utils.db import update_if_changed
 from .core_entities_sync import upsert_user_from_github
 from syncer.models.pull_request import PullRequest
@@ -65,7 +64,6 @@ def upsert_pull_request(bundle: Dict[str, Any], repo: Repository) -> PullRequest
 
     number = int(bundle.get("number", 0))
     pr = PullRequest.objects.filter(repository=repo, number=number).first()
-    created = False
 
     core_values = {
         "author": author_obj,
@@ -91,7 +89,6 @@ def upsert_pull_request(bundle: Dict[str, Any], repo: Repository) -> PullRequest
         pr = PullRequest(repository=repo, number=number, **core_values)
         pr.last_synced_at = timezone.now()
         pr.save()
-        created = True
         return PullRequestUpsertResult(pr=pr, created=True, updated_fields=tuple(core_values.keys()))
 
     # Existing: update only changed core fields.

--- a/qb_site/syncer/tests/backfill/test_sync_pr_backfill_only.py
+++ b/qb_site/syncer/tests/backfill/test_sync_pr_backfill_only.py
@@ -6,8 +6,7 @@ from django.test import TestCase
 from django.utils import timezone
 from django.conf import settings
 
-from core.models import Repository
-from syncer.models import PullRequest, PRTimelineEvent
+from syncer.models import PRTimelineEvent
 from syncer.tasks.sync_tasks import sync_pr_task
 from syncer.tests.factories import make_repo, make_pr
 

--- a/qb_site/syncer/tests/management/test_enqueue_repo_sync_cmd.py
+++ b/qb_site/syncer/tests/management/test_enqueue_repo_sync_cmd.py
@@ -6,7 +6,6 @@ from unittest import mock
 from django.core.management import call_command
 from django.test import TestCase
 
-from core.models import Repository
 from syncer.tests.factories import make_repo
 
 

--- a/qb_site/syncer/tests/management/test_sync_repo_cmd.py
+++ b/qb_site/syncer/tests/management/test_sync_repo_cmd.py
@@ -7,8 +7,6 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-from core.models import Repository
-from syncer.models import PullRequest
 from syncer.tests.factories import make_repo, make_pr
 
 

--- a/qb_site/syncer/tests/services/test_commit_history.py
+++ b/qb_site/syncer/tests/services/test_commit_history.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from core.models import Repository
 from syncer.services.commit_history import harvest_commit_history_shas, harvest_commit_history_with_cursor
-from syncer.models import PullRequest, CommitHistoryHarvest
+from syncer.models import PullRequest
 
 
 class FakeClient:

--- a/qb_site/syncer/tests/services/test_core_entities_sync.py
+++ b/qb_site/syncer/tests/services/test_core_entities_sync.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from django.test import TestCase
 
-from core.models.repository import Repository
-from core.models import User
 from syncer.services.sub.core_entities_sync import upsert_repo_node_id, upsert_user_from_github
 from syncer.tests.factories import make_repo
 

--- a/qb_site/syncer/tests/subsystems/test_labels_sync.py
+++ b/qb_site/syncer/tests/subsystems/test_labels_sync.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from django.test import TestCase
-from django.utils import timezone
 
-from core.models.repository import Repository
-from syncer.models import LabelDef, PullRequest, PRLabel
+from syncer.models import LabelDef, PRLabel
 from syncer.services.sub.labels_sync import sync_label_catalog, sync_pr_labels
 from syncer.tests.factories import make_repo, make_pr
 
@@ -20,8 +18,8 @@ class TestLabelsSync(TestCase):
         self.assertEqual(LabelDef.objects.filter(repository=self.repo).count(), 1)
         self.assertGreaterEqual(res.created, 1)
 
-        attach_res = sync_pr_labels(self.pr, ["easy"])  # lower-case
+        sync_pr_labels(self.pr, ["easy"])  # lower-case
         self.assertEqual(PRLabel.objects.filter(pull_request=self.pr).count(), 1)
         # Remove
-        attach_res2 = sync_pr_labels(self.pr, [])
+        sync_pr_labels(self.pr, [])
         self.assertEqual(PRLabel.objects.filter(pull_request=self.pr).count(), 0)

--- a/qb_site/syncer/tests/tasks/test_sync_pr_task_budget.py
+++ b/qb_site/syncer/tests/tasks/test_sync_pr_task_budget.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 from django.test import TestCase
 
-from core.models import Repository
 from syncer.tasks.sync_tasks import sync_pr_task
 from syncer.tests.factories import make_repo
 

--- a/qb_site/syncer/tests/test_pr_sync_integration.py
+++ b/qb_site/syncer/tests/test_pr_sync_integration.py
@@ -650,7 +650,6 @@ class TestPRSyncIntegration(TestCase):
             },
         }
         res1 = svc.sync_pull_request_bundle(self.repo, bundle1, dry_run=False)
-        pr = PullRequest.objects.get(repository=self.repo, number=3)
         self.assertEqual(CommitCheckRun.objects.filter(repository=self.repo, head_sha="h1").count(), 1)
         self.assertEqual(CommitStatusContext.objects.filter(repository=self.repo, head_sha="h1").count(), 1)
         self.assertEqual(res1["checkruns_upserted"], 1)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,5 @@
 line-length = 130
 extend-exclude = ["qb_site/**/migrations"]
+
+[lint.per-file-ignores]
+"qb_site/qb_site/settings/*.py" = ["F405"]


### PR DESCRIPTION
- Remove 20 unused imports (F401) via ruff --fix
- Remove 5 unused local variable assignments (F841)
- Fix E402 in rate_budget.py by moving module docstring before __future__ import
- Suppress F405 in settings/*.py via ruff.toml per-file-ignores (expected Django star-import pattern)
- Add ruff check step to GitHub Actions checks job so violations block CI
- Update AGENTS.md to require both ruff check and ruff format to pass before every commit

prepared with Claude code