### PR TITLE
fix(dashboard): escape raw PR body in hidden description cell and PR title

### DIFF
--- a/src/queueboard/dashboard.py
+++ b/src/queueboard/dashboard.py
@@ -133,7 +133,9 @@ def user_link(author_name: str, details: str | None = None) -> str:
 
 # An HTML link to a mathlib PR from the PR title
 def title_link(title: str, url: str) -> str:
-    return f"<a href='{url}'>{title}</a>"
+    # The title is untrusted text and may contain characters such as < > & that would
+    # otherwise be interpreted as HTML (breaking layout or enabling injection); escape it.
+    return f"<a href='{url}'>{html.escape(title)}</a>"
 
 
 # Create a button showing this label's title, and linking to the set of

--- a/src/queueboard/dashboard.py
+++ b/src/queueboard/dashboard.py
@@ -5,6 +5,7 @@
 # QUEUEBOARD_API_BASE_URL into the API directory before rendering.
 
 import argparse
+import html
 import json
 import os
 import sys
@@ -241,7 +242,11 @@ def _compute_pr_entries(
         # Mild HACK: if a PR has label "t-algebra", we append the hidden string "label:t-algebra$" to make this searchable.
         label_hack = hide("label:t-algebra$") if "t-algebra" in [lab.name for lab in pr.labels] else ""
         branch_name = pr_info.branch_name if pr_info is not None else "missing"
-        description = pr_info.description if pr_info is not None else ""
+        # The PR body is raw, untrusted text (often markdown with embedded HTML, e.g. dependabot
+        # release notes). It goes into a hidden, search-only column, so escape it: raw tags would
+        # otherwise break the surrounding table structure (an upstream length cap can even slice the
+        # body mid-tag, leaving unbalanced HTML that drops trailing cells) and are an XSS vector.
+        description = html.escape(pr_info.description) if pr_info is not None else ""
         # Mild HACK: append each PR's author as "author:name" to the end of the author column (hidden),
         # to allow for searches "author:name".
         author_hack = hide(f"author:{name}")


### PR DESCRIPTION
DataTables emitted "Requested unknown parameter '12' for row 381" on
review_dashboard.html#t-queue. The PR body was injected verbatim into
the hidden, search-only Description column. For a dependabot PR with a
huge release-notes body, an upstream 64 KB length cap sliced the body
mid-tag, leaving unbalanced `<ul>/<li>/<details>/<a>` HTML. The browser's
table parser then auto-closed the `<td>/<tr>` early, dropping the two
trailing cells, so the row had 12 cells instead of 14.

Escape the body with html.escape before placing it in the cell. The
column is hidden and only feeds DataTables search, so escaped text keeps
search working while making the content inert: raw tags can no longer
break the row (mid-tag truncation is now harmless) and the cell is no
longer an XSS vector.

We also escape the PR title to prevent similar issues.

Verified by reproducing a row with an unclosed-tag body: it now renders
all 14 cells, and a full regenerate of the fixture dashboards shows zero
misaligned rows.

Prepared with Claude code.