### PR TITLE
fix: emit ISO 8601 for Zulip global-time <time:> tags

### DIFF
--- a/qb_site/analyzer/services/reviewer_attention_format.py
+++ b/qb_site/analyzer/services/reviewer_attention_format.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from analyzer.services.reviewer_attention import ReviewerAttentionItem
+from core.utils.zulip_time import format_global_time
 
 CONSECUTIVE_QUEUE_TIME_SINCE_ASSIGNMENT_LABEL = "Consecutive time on queue since latest assignment"
 TOTAL_QUEUE_TIME_LABEL = "Total queue time"
@@ -37,7 +38,7 @@ def format_since_timestamp(ts: datetime | None, *, now: datetime | None = None) 
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
     total_seconds = max(int((now_ts - ts).total_seconds()), 0)
-    return f"<time:{int(ts.timestamp())}> ({format_compact_duration(total_seconds)} ago)"
+    return f"{format_global_time(ts)} ({format_compact_duration(total_seconds)} ago)"
 
 
 def sort_by_assignment_recency(items: list[ReviewerAttentionItem]) -> list[ReviewerAttentionItem]:

--- a/qb_site/analyzer/tasks/reviewer_attention.py
+++ b/qb_site/analyzer/tasks/reviewer_attention.py
@@ -26,6 +26,7 @@ from analyzer.services.reviewer_attention_format import (
 from core.services.github_assignment import AssignmentMutationError, GitHubAssignmentClient
 from core.services.github_operation_tokens import resolve_github_app_operation_token
 from core.models import Repository, User
+from core.utils.zulip_time import format_global_time
 from zulip_bot.services.zulip_client import ZulipApiError, ZulipClient
 
 
@@ -295,7 +296,7 @@ def _render_reviewer_message(
     lines: list[str] = [
         "### Assigned queue PRs that may need your attention",
         "",
-        f"Generated at <time:{_now_utc_unix()}>.",
+        f"Generated at {format_global_time(_now_utc_unix())}.",
         "",
     ]
 

--- a/qb_site/core/tests/test_zulip_time.py
+++ b/qb_site/core/tests/test_zulip_time.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from django.test import SimpleTestCase
+
+from core.utils.zulip_time import format_global_time
+
+
+class FormatGlobalTimeTests(SimpleTestCase):
+    def test_utc_datetime_renders_iso_8601(self) -> None:
+        dt = datetime(2025, 12, 2, 20, 40, 0, tzinfo=timezone.utc)
+        self.assertEqual(format_global_time(dt), "<time:2025-12-02T20:40:00+00:00>")
+
+    def test_naive_datetime_assumed_utc(self) -> None:
+        dt = datetime(2025, 12, 2, 20, 40, 0)
+        self.assertEqual(format_global_time(dt), "<time:2025-12-02T20:40:00+00:00>")
+
+    def test_non_utc_datetime_normalized_to_utc(self) -> None:
+        from datetime import timedelta
+
+        eastern = timezone(timedelta(hours=-5))
+        dt = datetime(2025, 12, 2, 15, 40, 0, tzinfo=eastern)
+        self.assertEqual(format_global_time(dt), "<time:2025-12-02T20:40:00+00:00>")
+
+    def test_unix_timestamp_int(self) -> None:
+        ts = int(datetime(2025, 12, 2, 20, 40, 0, tzinfo=timezone.utc).timestamp())
+        self.assertEqual(format_global_time(ts), "<time:2025-12-02T20:40:00+00:00>")
+
+    def test_sub_second_precision_truncated(self) -> None:
+        dt = datetime(2025, 12, 2, 20, 40, 0, 123456, tzinfo=timezone.utc)
+        self.assertEqual(format_global_time(dt), "<time:2025-12-02T20:40:00+00:00>")
+
+    def test_output_parses_with_fromisoformat(self) -> None:
+        # Mirrors how Zulip's markdown parser resolves <time:...> values since
+        # Zulip 12.0 (feature level 451): datetime.fromisoformat on the inner
+        # string. A bare Unix timestamp would raise ValueError here.
+        dt = datetime(2025, 12, 2, 20, 40, 0, tzinfo=timezone.utc)
+        rendered = format_global_time(dt)
+        inner = rendered.removeprefix("<time:").removesuffix(">")
+        self.assertEqual(datetime.fromisoformat(inner), dt)

--- a/qb_site/core/utils/zulip_time.py
+++ b/qb_site/core/utils/zulip_time.py
@@ -1,0 +1,34 @@
+"""Helpers for rendering Zulip "global time" markdown tags.
+
+Zulip's markdown ``<time:...>`` syntax renders an instant in each reader's local
+timezone. As of Zulip 12.0 (server feature level 451) the markdown parser
+resolves the value with :func:`datetime.datetime.fromisoformat` and no longer
+accepts bare Unix timestamps -- an unparseable value is rendered as escaped
+literal text (``&lt;time:...&gt;``) instead of a localized time. Always emit
+ISO 8601 here.
+
+References:
+- https://github.com/zulip/zulip/pull/36837
+- https://zulip.com/help/global-times
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def format_global_time(value: datetime | int | float) -> str:
+    """Return a Zulip ``<time:...>`` global-time tag for ``value`` using ISO 8601.
+
+    ``value`` may be a timezone-aware ``datetime`` (a naive one is assumed UTC)
+    or a Unix timestamp. The instant is normalized to UTC and formatted with
+    second resolution, e.g. ``<time:2025-12-02T20:40:00+00:00>`` -- the same
+    shape Zulip's own ``datetime_to_global_time`` helper emits.
+    """
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        dt = datetime.fromtimestamp(value, tz=timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"<time:{dt.astimezone(timezone.utc).isoformat(timespec='seconds')}>"

--- a/qb_site/zulip_bot/commands/assigned_prs.py
+++ b/qb_site/zulip_bot/commands/assigned_prs.py
@@ -15,6 +15,7 @@ from analyzer.services.reviewer_attention_format import (
 )
 from analyzer.services.reviewer_attention import ReviewerAttentionItem, ReviewerAttentionReport, build_reviewer_attention_reports
 from core.models import Repository, ReviewerPreference, User
+from core.utils.zulip_time import format_global_time
 from syncer.models import PRLabel, PullRequest
 from zulip_bot.commands import CommandContext, CommandResult, register_command
 from zulip_bot.services.zulip_client import ZulipApiError, ZulipClient
@@ -179,8 +180,7 @@ def _render_assigned_prs_report(
         lines.append("No assigned PR data is available for your configured repositories.")
         return "\n".join(lines)
 
-    now_unix = _now_utc_unix()
-    lines.append(f"Generated at <time:{now_unix}>.")
+    lines.append(f"Generated at {format_global_time(_now_utc_unix())}.")
 
     any_assigned = False
     for repo_label, report, extras_by_pr in reports:

--- a/qb_site/zulip_bot/commands/close_pr.py
+++ b/qb_site/zulip_bot/commands/close_pr.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from core.models import User
+from core.utils.zulip_time import format_global_time
 from zulip_bot.commands import CommandContext, CommandResult, register_command
 from zulip_bot.services.assignment_command_parser import AssignmentCommandParseError, _parse_single_pr_ref
 from zulip_bot.services.close_pr_execution import PermissionOutcome, check_close_pr_permission
@@ -96,12 +97,11 @@ def close_pr_command(context: CommandContext, args: str) -> CommandResult:
     )
     ttl_seconds = int(getattr(settings, "ZULIP_CLOSE_PR_TOKEN_TTL_SECONDS", 1800))
     expires_at = timezone.now() + timedelta(seconds=ttl_seconds)
-    expires_unix = int(expires_at.timestamp())
     pr_ref = f"`{pr.owner}/{pr.repo}#{pr.number}`"
     title_suffix = f' ("{result.pr_title}")' if result.pr_title else ""
     dm_content = (
         f"Use this private link to [confirm closing PR {pr_ref}{title_suffix}]({link}). "
-        f"It expires at <time:{expires_unix}>. "
+        f"It expires at {format_global_time(expires_at)}. "
         "The close will be attributed to the bot, not your personal GitHub account."
     )
     try:

--- a/qb_site/zulip_bot/commands/label_pr.py
+++ b/qb_site/zulip_bot/commands/label_pr.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from core.models import User
+from core.utils.zulip_time import format_global_time
 from zulip_bot.commands import CommandContext, CommandResult, register_command
 from zulip_bot.services.assignment_command_parser import AssignmentCommandParseError, _parse_single_issue_or_pr_ref
 from zulip_bot.services.close_pr_execution import PermissionOutcome
@@ -94,12 +95,11 @@ def label_pr_command(context: CommandContext, args: str) -> CommandResult:
     )
     ttl_seconds = int(getattr(settings, "ZULIP_LABEL_PR_TOKEN_TTL_SECONDS", 1800))
     expires_at = timezone.now() + timedelta(seconds=ttl_seconds)
-    expires_unix = int(expires_at.timestamp())
     ref_str = f"`{ref.owner}/{ref.repo}#{ref.number}`"
     title_suffix = f' ("{result.pr_title}")' if result.pr_title else ""
     dm_content = (
         f"Use this private link to [edit labels on {ref_str}{title_suffix}]({link}). "
-        f"It expires at <time:{expires_unix}>. "
+        f"It expires at {format_global_time(expires_at)}. "
         "The change will be attributed to the bot, not your personal GitHub account."
     )
     try:

--- a/qb_site/zulip_bot/commands/prefs.py
+++ b/qb_site/zulip_bot/commands/prefs.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from core.models import ReviewerPreference, User
+from core.utils.zulip_time import format_global_time
 from zulip_bot.commands import CommandContext, CommandResult, register_command
 from zulip_bot.services.prefs_links import PrefsLinkClaims, build_prefs_link
 from zulip_bot.services.registration_links import RegistrationLinkClaims, build_registration_link
@@ -38,11 +39,10 @@ def prefs_command(context: CommandContext, args: str) -> CommandResult:
         )
         ttl_seconds = int(getattr(settings, "ZULIP_REGISTRATION_TOKEN_TTL_SECONDS", 1800))
         expires_at = timezone.now() + timedelta(seconds=ttl_seconds)
-        expires_unix = int(expires_at.timestamp())
         dm_content = (
             "No reviewer profile is linked to your Zulip account yet. "
             f"Use this private link to [start registration]({register_link}). "
-            f"It expires at <time:{expires_unix}>."
+            f"It expires at {format_global_time(expires_at)}."
         )
         return _send_dm(context.sender_id, dm_content, "prefs_registration_dm_failed")
 
@@ -61,8 +61,9 @@ def prefs_command(context: CommandContext, args: str) -> CommandResult:
     )
     ttl_seconds = int(getattr(settings, "ZULIP_PREFS_TOKEN_TTL_SECONDS", 1800))
     expires_at = timezone.now() + timedelta(seconds=ttl_seconds)
-    expires_unix = int(expires_at.timestamp())
-    dm_content = f"Use this private link to [open your reviewer preferences form]({link}). It expires at <time:{expires_unix}>."
+    dm_content = (
+        f"Use this private link to [open your reviewer preferences form]({link}). It expires at {format_global_time(expires_at)}."
+    )
     return _send_dm(context.sender_id, dm_content, "prefs_link_dm_failed")
 
 

--- a/qb_site/zulip_bot/commands/register_test.py
+++ b/qb_site/zulip_bot/commands/register_test.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 
+from core.utils.zulip_time import format_global_time
 from zulip_bot.commands import CommandContext, CommandResult, register_command
 from zulip_bot.services.registration_links import RegistrationLinkClaims, build_registration_link
 from zulip_bot.services.zulip_client import ZulipApiError, ZulipClient
@@ -34,9 +35,9 @@ def register_test_command(context: CommandContext, args: str) -> CommandResult:
     )
     ttl_seconds = int(getattr(settings, "ZULIP_REGISTRATION_TOKEN_TTL_SECONDS", 1800))
     expires_at = timezone.now() + timedelta(seconds=ttl_seconds)
-    expires_unix = int(expires_at.timestamp())
     dm_content = (
-        f"Use this private link to [test registration via GitHub OAuth]({register_link}). It expires at <time:{expires_unix}>."
+        f"Use this private link to [test registration via GitHub OAuth]({register_link}). "
+        f"It expires at {format_global_time(expires_at)}."
     )
     # Private links must be delivered via send_direct_message. See close_pr.py
     # for the rationale: Zulip webhook responses always go back to the triggering

--- a/qb_site/zulip_bot/tests/commands/test_prefs_command.py
+++ b/qb_site/zulip_bot/tests/commands/test_prefs_command.py
@@ -38,7 +38,7 @@ class TestPrefsCommand(TestCase):
         dm_content = mock_client.send_direct_message.call_args.kwargs["content"]
         self.assertIn("[open your reviewer preferences form](", dm_content)
         self.assertIn("https://queueboard.example/api/zulip/prefs/", dm_content)
-        self.assertRegex(dm_content, re.compile(r"<time:\d+>"))
+        self.assertRegex(dm_content, re.compile(r"<time:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00>"))
 
     @patch("zulip_bot.commands.prefs.ZulipClient")
     def test_prefs_command_handles_missing_user_link(self, MockZulipClient: MagicMock) -> None:
@@ -50,7 +50,7 @@ class TestPrefsCommand(TestCase):
         self.assertIn("No reviewer profile is linked", dm_content)
         self.assertIn("[start registration](", dm_content)
         self.assertIn("https://queueboard.example/api/zulip/register/", dm_content)
-        self.assertRegex(dm_content, re.compile(r"<time:\d+>"))
+        self.assertRegex(dm_content, re.compile(r"<time:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00>"))
 
     def test_prefs_command_handles_missing_preferences(self) -> None:
         User.objects.create(github_login="reviewer", zulip_user_id=101)

--- a/qb_site/zulip_bot/tests/commands/test_register_test_command.py
+++ b/qb_site/zulip_bot/tests/commands/test_register_test_command.py
@@ -33,7 +33,7 @@ class TestRegisterTestCommand(SimpleTestCase):
         dm_content = mock_client.send_direct_message.call_args.kwargs["content"]
         self.assertIn("[test registration via GitHub OAuth](", dm_content)
         self.assertIn("https://queueboard.example/api/zulip/register/", dm_content)
-        self.assertRegex(dm_content, re.compile(r"<time:\d+>"))
+        self.assertRegex(dm_content, re.compile(r"<time:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00>"))
 
     def test_register_test_handles_missing_sender_identity(self) -> None:
         result = register_test_command(self._context(sender_id=None), "")

--- a/qb_site/zulip_bot/views.py
+++ b/qb_site/zulip_bot/views.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
 from core.models import ReviewerPreference, User
+from core.utils.zulip_time import format_global_time
 from syncer.models import LabelDef
 from zulip_bot.commands import CommandResult, get_command
 from zulip_bot.commands import assign as _assign  # noqa: F401
@@ -897,7 +898,7 @@ def _send_registration_success_dm(
         content = (
             f"Successfully linked your Zulip account with GitHub user `{github_login}`.\n\n"
             f"Next step: click this private link to [finalize your reviewer preferences]({prefs_link}). "
-            f"It expires at <time:{prefs_expires_unix}>."
+            f"It expires at {format_global_time(prefs_expires_unix)}."
         )
     else:
         content = (


### PR DESCRIPTION
Zulip's markdown <time:...> parser no longer accepts bare Unix
timestamps. As of server feature level 503 (https://github.com/zulip/zulip/pull/39207, "Remove
dateutil") the handler resolves the value with datetime.fromisoformat
and dropped the dateutil/Unix-timestamp fallback; combined with feature
level 451 (https://github.com/zulip/zulip/issues/36374), an unparseable value now renders as
escaped literal text (&lt;time:...&gt;) instead of a localized time.

Our bot/task DMs emitted <time:{unix}>, so they started showing the raw
tag text. Add a shared core.utils.zulip_time.format_global_time helper
that renders ISO 8601 (e.g. <time:2025-12-02T20:40:00+00:00>, matching
Zulip's own datetime_to_global_time output and parseable by
datetime.fromisoformat across Python versions), and route every emitting
site through it:

- zulip_bot/commands: close_pr, label_pr, prefs (x2), register_test,
  assigned_prs
- zulip_bot/views: registration success DM
- analyzer: reviewer_attention task + reviewer_attention_format service

Update the two regex tests that asserted the numeric form and add unit
tests for the helper (UTC/naive/offset datetimes, Unix ints, sub-second
truncation, and a fromisoformat round-trip mirroring Zulip's parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)