### PR TITLE
fix(analyzer): track current PR head in revision builder when CI is absent

### DIFF
--- a/docs/design-decisions/047-revision-builder-tracks-current-head-without-ci.md
+++ b/docs/design-decisions/047-revision-builder-tracks-current-head-without-ci.md
@@ -1,0 +1,119 @@
+# Revision Builder Tracks the Current Head Even Without CI or a Force-Push Event
+
+## Context
+
+`PRRevision` rows are the analyzer's record of a PR's head-SHA history over
+time. They are built by `rebuild_pr_revisions` (`analyzer/services/revisions.py`)
+from two signals only:
+
+1. `HEAD_FORCE_PUSHED` timeline events (`before_sha`/`after_sha`), and
+2. commits that carry CI rows (`CommitCheckRun` / `CommitStatusContext`), via
+   `_collect_ci_first_seen`.
+
+`pr.head_sha` (the authoritative current head, set from the bundle's
+`headRefOid`) is used only as a last-resort *seed* in `_infer_seed_sha`, and
+only when no CI windows can be derived at all.
+
+These revisions feed the queue-window builder (`queue_windows.py`), which
+evaluates required CI **against the head SHA of the revision active at each
+boundary** (`_head_sha_at_time`). The snapshot's separate queue-candidate path
+(`queueboard_snapshot._ci_status_for_pr`) instead reads `pr.head_sha` directly.
+When those two head sources disagree, the two paths disagree about queue
+membership.
+
+### The failure (leanprover-community/mathlib4#40601)
+
+A fork PR was created at head `6ee0b95`; its required `Build` check **failed**,
+correctly taking it off the queue. The author then advanced the head to
+`1049e60a` with an ordinary commit push (no rebase), so:
+
+- GitHub emitted **no** `HEAD_REF_FORCE_PUSHED` event, and
+- CI for `1049e60a` was **skipped** (the changed files were outside the build
+  workflows' path filters), so no `CommitCheckRun`/`CommitStatusContext` rows
+  ever existed for it.
+
+The revision builder had neither of its two signals for `1049e60a`, so it stayed
+pinned to `6ee0b95`. The queue-window builder kept gating on `6ee0b95`'s failed
+`Build` and reported the PR off-queue indefinitely — for 8 days — while the
+snapshot's candidate path (reading `pr.head_sha = 1049e60a`, missing CI →
+eligible under `no_required_failures`) listed it on-queue. Re-syncing could not
+help: GitHub returns the same data every time. Under the repo's configured
+`no_required_failures` gating (missing/pending CI is eligible; only an explicit
+failure gates), the PR *should* be on the queue.
+
+## Decision
+
+Make `rebuild_pr_revisions` always reflect the PR's actual current head.
+
+- New helper `_ensure_current_head_window`: after the force-push/CI windows are
+  computed, if `pr.head_sha` differs from the last derived head, close the
+  trailing window and append an open-ended window for `pr.head_sha`. No-op when
+  `head_sha` is unset or already matches (the common case, including normal
+  force-push PRs whose last `after_sha` is the current head).
+- `rebuild_pr_revisions` now forces a rebuild (skips the noop short-circuit)
+  when the trailing revision head ≠ `pr.head_sha`. A plain push with no CI does
+  not advance any time-based signal past `built_through_ts`, so without this the
+  noop guard would never pick the new head up.
+- The incremental "append" strategy now verifies that the immutable prefix
+  (windows before the current tail) still matches what we re-derive; if not, it
+  falls back to a full rebuild. This is needed because a synthetic current-head
+  window can later be *superseded* by a CI/force-push-derived window at a
+  different time (e.g. CI finally runs for a fork head), which moves an earlier
+  window's `to_ts` — something the forward-only append path would otherwise skip,
+  leaving a revision coverage gap.
+
+### Dating the boundary without a push time
+
+GitHub does **not** expose when a commit was *pushed* to a branch. Commit
+`committedDate` is the author/commit time — for a rebase or cherry-pick it can
+be much earlier than the push, which would place the boundary in the past and
+*over*-count queue time. So we deliberately do **not** add a `committedDate`
+column.
+
+`_current_head_change_ts` instead uses `pr.gh_updated_at` as the push-time
+proxy: the push bumps the PR's `updatedAt`, and our detection of the new head is
+*triggered* by that bump, so at first detection `gh_updated_at` ≈ push time and
+is an *upper* bound (conservative — it under-counts rather than over-counts queue
+time). To prevent drift when later comments/labels bump `updatedAt`, once a
+revision window exists for the head *as a continuation* (its `from_ts` is after
+the last derived window) that `from_ts` is **reused** on subsequent rebuilds
+rather than recomputed. An *earlier* existing window for the same head means the
+head was superseded and has since returned (a revert), so it is not reused — the
+re-push's `gh_updated_at` is used instead. The value is clamped to never sit in
+the future and to fall strictly after the previous window's start.
+
+This timestamp affects only queue-*time* accounting (`first_on_queue_ts`,
+`total_time_on_queue`); the on/off-queue determination is correct for any
+`from_ts <= now`.
+
+## Edge cases and limitations
+
+- **Intermediate transient heads** (A→B→C in quick succession where B has no CI
+  and no force-push event) are not recorded — there is no signal that B existed
+  nor any timestamp for it. The builder correctly lands on the current head C;
+  only the brief B interval is absent from history.
+- **`timeline_backfill_done` precondition**: `rebuild_pr_revisions` returns early
+  (`skipped`) before the head check when timeline backfill is incomplete, so a
+  not-yet-backfilled PR keeps a stale head until backfill finishes.
+- **Reliance on `pr.head_sha`**: the fix tracks whatever the syncer records as
+  the head. This is sound for live syncs (the "newer-wins" guard that could keep
+  an older `head_sha` is archive-import-only); a broader syncer bug that left
+  `head_sha` stale would still mislead the builder.
+- The boundary timestamps are deliberate approximations (see above); they affect
+  queue-time accounting only, never the on/off-queue result.
+
+## Consequences
+
+- The queue-window builder and the snapshot candidate path now evaluate CI
+  against the same head (`pr.head_sha`), eliminating the contradictory
+  on/off-queue signals.
+- For #40601 and the whole class of fork-PR-without-CI cases, a revision for the
+  real current head is created; with no failing required CI on that head, the
+  PR re-enters the queue under `no_required_failures`.
+- When the trailing window is first created, `revision_version` bumps, so the
+  queue-window sweep (`analyzer.rebuild_queue_windows_sweep`) rebuilds the
+  affected windows. Subsequent rebuilds reuse the stored boundary → no churn.
+- Rollout for the stuck PR: deploy, then
+  `manage.py rebuild_revisions --repo leanprover-community/mathlib4 --pr 40601`
+  (the queue-window sweep then picks up the revision-version bump). No migration
+  or resync is required — this is a pure analyzer-side change.

--- a/qb_site/analyzer/AGENTS.md
+++ b/qb_site/analyzer/AGENTS.md
@@ -19,7 +19,7 @@
 docker compose exec -T web env DJANGO_SETTINGS_MODULE=qb_site.settings.ci python qb_site/manage.py test analyzer
 
 # Rebuild revisions command
-docker compose exec -T web python qb_site/manage.py rebuild_revisions --repo leanprover-community/mathlib4 --number 30723
+docker compose exec -T web python qb_site/manage.py rebuild_revisions --repo leanprover-community/mathlib4 --pr 30723
 
 # Plan CI backfill command
 docker compose exec -T web python qb_site/manage.py plan_ci_backfill --repo leanprover-community/mathlib4 --enqueue

--- a/qb_site/analyzer/services/revisions.py
+++ b/qb_site/analyzer/services/revisions.py
@@ -319,6 +319,92 @@ def _latest_signal_ts(pr: PullRequest) -> Optional[datetime]:
     return latest
 
 
+def _current_head_change_ts(
+    pr: PullRequest,
+    *,
+    prev_from_ts: Optional[datetime],
+    existing_head_from_ts: Optional[datetime],
+) -> datetime:
+    """Pick a stable timestamp for when ``pr.head_sha`` became the current head.
+
+    GitHub does not expose when a commit was *pushed* to the branch (commit
+    ``committedDate`` is the author/commit time, which for rebases can be much
+    earlier than the push). The closest signal we have is ``gh_updated_at``: the
+    push bumps the PR's ``updatedAt``, and our detection of the new head is itself
+    triggered by that bump, so at first detection ``gh_updated_at`` approximates the
+    push time and is an upper bound (conservative — it under-counts queue time
+    rather than over-counting it).
+
+    Preference order:
+    1. The ``from_ts`` of an already-recorded window for this head, but only when it
+       sits *after* the last derived window — i.e. it is a genuine continuation from a
+       prior rebuild (reused so the boundary stays stable when ``gh_updated_at`` later
+       drifts on unrelated comment/label activity). An earlier existing window for the
+       same head means the head was superseded and has now returned (a revert), so we
+       do NOT reuse it.
+    2. ``pr.gh_updated_at`` — the push-time proxy used on first detection / re-push.
+
+    The result is clamped to never sit in the future and to fall strictly after the
+    previous window's start so window ordering stays valid. This timestamp affects
+    only queue-time accounting; on/off-queue determination is correct for any
+    ``from_ts <= now``.
+    """
+    now = timezone.now()
+    if existing_head_from_ts is not None and (prev_from_ts is None or existing_head_from_ts > prev_from_ts):
+        ts = existing_head_from_ts
+    else:
+        ts = getattr(pr, "gh_updated_at", None) or now
+    if timezone.is_naive(ts):
+        ts = timezone.make_aware(ts)
+    if ts > now:
+        ts = now
+    if prev_from_ts is not None and ts <= prev_from_ts:
+        ts = prev_from_ts + timedelta(seconds=1)
+    return ts
+
+
+def _ensure_current_head_window(
+    pr: PullRequest,
+    windows: List[Tuple[datetime, str, Optional[datetime]]],
+) -> List[Tuple[datetime, str, Optional[datetime]]]:
+    """Ensure the trailing open-ended window tracks ``pr.head_sha``.
+
+    The builder derives heads from HEAD_FORCE_PUSHED events and CI-bearing commits.
+    A plain commit push whose CI never ran (e.g. a fork PR whose workflows were
+    skipped or are awaiting approval) leaves ``pr.head_sha`` ahead of every derived
+    head, so the trailing window would otherwise track a stale commit and gate the
+    PR on outdated CI. When the current head differs from the last derived head,
+    close the previous window and append a trailing window for the real current head.
+
+    No-op when ``pr.head_sha`` is unset or already matches the last derived head (the
+    common case, including force-push PRs whose final after_sha is the current head).
+    """
+    head = (getattr(pr, "head_sha", None) or "").strip()
+    if not head:
+        return windows
+    if windows and (windows[-1][1] or "") == head:
+        return windows
+    existing_head_from_ts = (
+        PRRevision.objects.filter(pull_request=pr, head_sha=head)
+        .order_by("from_ts", "seq", "id")
+        .values_list("from_ts", flat=True)
+        .first()
+    )
+    if not windows:
+        start = pr.gh_created_at if pr.gh_created_at else timezone.now()
+        return [(start, head, None)]
+    last_from, last_head, _last_to = windows[-1]
+    change_ts = _current_head_change_ts(
+        pr,
+        prev_from_ts=last_from,
+        existing_head_from_ts=existing_head_from_ts,
+    )
+    new_windows = list(windows)
+    new_windows[-1] = (last_from, last_head, change_ts)
+    new_windows.append((change_ts, head, None))
+    return new_windows
+
+
 @transaction.atomic
 def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] = None) -> RebuildResult:
     """Rebuild head revision windows for a PR from timeline events and CI.
@@ -361,8 +447,18 @@ def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] =
         needs_full = True
 
     has_existing = PRRevision.objects.filter(pull_request=pr).exists()
+    # Force a rebuild when the PR's current head is not yet the trailing revision head.
+    # A plain commit push (no force-push event) whose CI never ran does not advance any
+    # time-based signal past built_through_ts, so without this the noop short-circuit
+    # would leave the analyzer pinned to a stale head (see design decision 047).
+    current_head = (pr.head_sha or "").strip()
+    head_mismatch = False
+    if current_head:
+        tail_rev = PRRevision.objects.filter(pull_request=pr).order_by("-from_ts", "-seq", "-id").first()
+        head_mismatch = tail_rev is None or (tail_rev.head_sha or "") != current_head
     if (
         not needs_full
+        and not head_mismatch
         and state.built_through_ts
         and latest_signal_ts
         and latest_signal_ts <= state.built_through_ts
@@ -397,6 +493,10 @@ def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] =
                 start = pr.gh_created_at if pr.gh_created_at else timezone.now()
                 expected.append((start, seed, None))
 
+    # Make sure the trailing window reflects the PR's actual current head, even when no
+    # force-push event or CI exists for it (e.g. a fork PR whose CI was skipped).
+    expected = _ensure_current_head_window(pr, expected)
+
     created = 0
 
     # When appending, preserve prefix windows and only rewrite from the current tail onward.
@@ -406,10 +506,27 @@ def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] =
         tail = PRRevision.objects.filter(pull_request=pr).order_by("-from_ts", "-seq", "-id").first()
         if tail:
             append_from_ts = tail.from_ts
-            seq_offset = PRRevision.objects.filter(pull_request=pr, from_ts__lt=append_from_ts).count()
-            expected = [(ft, sha, tt) for (ft, sha, tt) in expected if ft >= append_from_ts]
-            if not expected:
-                strategy = "noop"
+            # Append only rewrites windows from the tail onward and assumes the earlier
+            # windows are immutable. That assumption breaks when a prior synthetic
+            # current-head window is being superseded by a CI/force-push-derived window at
+            # a different time: an earlier window's to_ts would then need to move, which
+            # append would skip — leaving a coverage gap. Verify the immutable prefix still
+            # matches what we now derive; if not, fall back to a full rebuild.
+            prefix_expected = [(ft, sha, tt) for (ft, sha, tt) in expected if ft < append_from_ts]
+            prefix_existing = list(
+                PRRevision.objects.filter(pull_request=pr, from_ts__lt=append_from_ts)
+                .order_by("from_ts", "seq", "id")
+                .values_list("from_ts", "head_sha", "to_ts")
+            )
+            if prefix_expected != prefix_existing:
+                strategy = "full"
+                append_from_ts = None
+                seq_offset = 0
+            else:
+                seq_offset = len(prefix_existing)
+                expected = [(ft, sha, tt) for (ft, sha, tt) in expected if ft >= append_from_ts]
+                if not expected:
+                    strategy = "noop"
     if strategy == "noop":
         return RebuildResult(created=0, deleted=0, strategy="noop")
 

--- a/qb_site/analyzer/tests/test_pr_revisions.py
+++ b/qb_site/analyzer/tests/test_pr_revisions.py
@@ -89,6 +89,257 @@ class TestPRRevisions(TestCase):
         self.assertEqual(revs[0].from_ts, pr.gh_created_at)
         self.assertIsNone(revs[0].to_ts)
 
+    def _seed_old_head_state(self, pr: PullRequest, old_head: str) -> None:
+        """Simulate the state left by a prior build: one window + CI for an old head."""
+        created = pr.gh_created_at
+        PRRevision.objects.create(pull_request=pr, head_sha=old_head, from_ts=created, to_ts=None, seq=0)
+        CommitCheckRun.objects.create(
+            repository=self.repo,
+            github_node_id=f"CR_{old_head}",
+            head_sha=old_head,
+            name="ci",
+            status="COMPLETED",
+            conclusion="FAILURE",
+            details_url=None,
+            external_id=None,
+            gh_started_at=created + timezone.timedelta(minutes=5),
+            gh_completed_at=created + timezone.timedelta(minutes=10),
+        )
+        PRRevisionBuildState.objects.create(
+            pull_request=pr,
+            built_through_ts=created + timezone.timedelta(minutes=10),
+            dirty_from_ts=None,
+            builder_version=PR_REVISION_BUILDER_VERSION,
+        )
+
+    def test_trailing_window_for_current_head_without_ci_or_force_push(self) -> None:
+        # A fork PR whose newest commit had CI skipped: head advanced via a plain push,
+        # so there is no force-push event and no CI for the current head. The builder
+        # must still open a trailing window for pr.head_sha instead of staying pinned to
+        # the old, failed commit. The boundary is dated from gh_updated_at (push-time
+        # proxy) since GitHub does not expose the actual push time.
+        pr = self._mk_pr(40)
+        created = pr.gh_created_at
+        old_head, new_head = "oldhead0", "newhead9"
+        self._seed_old_head_state(pr, old_head)
+        t_push = created + timezone.timedelta(hours=2)
+        pr.head_sha = new_head
+        pr.gh_updated_at = t_push  # bumped by the push
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        res = rebuild_pr_revisions(pr)
+
+        self.assertNotEqual(res.strategy, "noop")
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual(len(revs), 2)
+        self.assertEqual(revs[0].head_sha, old_head)
+        self.assertEqual(revs[0].from_ts, created)
+        self.assertEqual(revs[0].to_ts, t_push)
+        self.assertEqual(revs[1].head_sha, new_head)
+        self.assertEqual(revs[1].from_ts, t_push)
+        self.assertIsNone(revs[1].to_ts)
+
+    def test_trailing_window_stable_across_rebuilds(self) -> None:
+        # Once the trailing window exists, a later rebuild must not move its from_ts or
+        # churn the revision_version: the boundary is reused from the existing window,
+        # not recomputed from a since-drifted gh_updated_at.
+        pr = self._mk_pr(42)
+        created = pr.gh_created_at
+        old_head, new_head = "oldhead2", "newhead2"
+        self._seed_old_head_state(pr, old_head)
+        pr.head_sha = new_head
+        pr.gh_updated_at = created + timezone.timedelta(hours=2)
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        rebuild_pr_revisions(pr)
+        state = PRRevisionBuildState.objects.get(pull_request=pr)
+        version_after_first = state.revision_version
+        trailing_from = PRRevision.objects.filter(pull_request=pr, head_sha=new_head).get().from_ts
+        self.assertEqual(trailing_from, created + timezone.timedelta(hours=2))
+
+        # Later unrelated activity drifts gh_updated_at forward and a CI re-run on the old
+        # head advances the latest signal, forcing another rebuild pass.
+        pr.gh_updated_at = created + timezone.timedelta(hours=6)
+        pr.save(update_fields=["gh_updated_at"])
+        CommitCheckRun.objects.create(
+            repository=self.repo,
+            github_node_id="CR_rerun",
+            head_sha=old_head,
+            name="ci",
+            status="COMPLETED",
+            conclusion="FAILURE",
+            details_url=None,
+            external_id=None,
+            gh_started_at=created + timezone.timedelta(hours=6),
+            gh_completed_at=created + timezone.timedelta(hours=6, minutes=5),
+        )
+
+        rebuild_pr_revisions(pr)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual(len(revs), 2)
+        self.assertEqual(revs[1].head_sha, new_head)
+        # Reused from the existing window — NOT moved to the drifted gh_updated_at.
+        self.assertEqual(revs[1].from_ts, trailing_from)
+        state.refresh_from_db()
+        self.assertEqual(state.revision_version, version_after_first)
+
+    def test_no_trailing_window_when_head_matches_force_push(self) -> None:
+        # Common case: pr.head_sha equals the last force-push after_sha -> no extra window.
+        pr = self._mk_pr(43)
+        t0 = pr.gh_created_at + timezone.timedelta(hours=1)
+        PRTimelineEvent.objects.create(
+            pull_request=pr,
+            type=PRTimelineEventType.HEAD_FORCE_PUSHED,
+            occurred_at=t0,
+            before_sha="h0",
+            after_sha="h1",
+        )
+        pr.head_sha = "h1"
+        pr.save(update_fields=["head_sha"])
+
+        rebuild_pr_revisions(pr)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual(len(revs), 2)
+        self.assertEqual(revs[-1].head_sha, "h1")
+        self.assertIsNone(revs[-1].to_ts)
+
+    def test_trailing_window_after_force_push_then_plain_push(self) -> None:
+        # Force-push to h1, then a plain commit push to h2 (no event, no CI): the builder
+        # appends a trailing window for h2 after the force-push-derived windows.
+        pr = self._mk_pr(44)
+        t0 = pr.gh_created_at + timezone.timedelta(hours=1)
+        t_push = pr.gh_created_at + timezone.timedelta(hours=3)
+        PRTimelineEvent.objects.create(
+            pull_request=pr,
+            type=PRTimelineEventType.HEAD_FORCE_PUSHED,
+            occurred_at=t0,
+            before_sha="h0",
+            after_sha="h1",
+        )
+        pr.head_sha = "h2"
+        pr.gh_updated_at = t_push
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        rebuild_pr_revisions(pr)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual(len(revs), 3)
+        self.assertEqual(revs[0].head_sha, "h0")
+        self.assertEqual(revs[0].to_ts, t0)
+        self.assertEqual(revs[1].head_sha, "h1")
+        self.assertEqual(revs[1].to_ts, t_push)
+        self.assertEqual(revs[2].head_sha, "h2")
+        self.assertEqual(revs[2].from_ts, t_push)
+        self.assertIsNone(revs[2].to_ts)
+
+    def test_head_mismatch_forces_rebuild_without_new_signal(self) -> None:
+        # A plain push with NO new CI and NO new timeline event does not advance any
+        # time-based signal, so the noop short-circuit would skip it. head_mismatch must
+        # force the rebuild so the current head is tracked.
+        pr = self._mk_pr(47)
+        created = pr.gh_created_at
+        PRRevision.objects.create(pull_request=pr, head_sha="h_old", from_ts=created, to_ts=None, seq=0)
+        built_through = created + timezone.timedelta(hours=1)
+        PRRevisionBuildState.objects.create(
+            pull_request=pr,
+            built_through_ts=built_through,
+            dirty_from_ts=None,
+            builder_version=PR_REVISION_BUILDER_VERSION,
+        )
+        pr.head_sha = "h_new"
+        pr.gh_updated_at = created + timezone.timedelta(minutes=30)
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        # latest_signal_ts (no CI/timeline) falls back to built_through, so only
+        # head_mismatch can prevent a noop here.
+        res = rebuild_pr_revisions(pr, latest_signal_ts=built_through)
+
+        self.assertNotEqual(res.strategy, "noop")
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual([r.head_sha for r in revs], ["h_new"])
+        self.assertIsNone(revs[-1].to_ts)
+
+    def test_trailing_window_handles_revert_to_prior_sha(self) -> None:
+        # Head A -> B (force-push), then reverted to A via a plain push (no event). A fresh
+        # A window is opened from the re-push (gh_updated_at), distinct from the original A
+        # window — the original window's start is NOT reused for the reverted head.
+        pr = self._mk_pr(45)
+        created = pr.gh_created_at
+        t0 = created + timezone.timedelta(hours=1)
+        t_repush = created + timezone.timedelta(hours=3)
+        PRTimelineEvent.objects.create(
+            pull_request=pr,
+            type=PRTimelineEventType.HEAD_FORCE_PUSHED,
+            occurred_at=t0,
+            before_sha="A",
+            after_sha="B",
+        )
+        pr.head_sha = "A"
+        pr.gh_updated_at = t_repush
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        rebuild_pr_revisions(pr)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual([r.head_sha for r in revs], ["A", "B", "A"])
+        self.assertEqual(revs[0].from_ts, created)
+        self.assertEqual(revs[0].to_ts, t0)
+        self.assertEqual(revs[1].from_ts, t0)
+        self.assertEqual(revs[1].to_ts, t_repush)
+        self.assertEqual(revs[2].from_ts, t_repush)
+        self.assertIsNone(revs[2].to_ts)
+
+    def test_trailing_window_redates_when_ci_arrives_later(self) -> None:
+        # A fork PR's CI-less current head gets a synthetic window from the push; later CI
+        # actually runs for it. The window is re-dated to the CI time WITHOUT leaving a
+        # coverage gap (the prior window's to_ts moves too), and then converges.
+        pr = self._mk_pr(46)
+        created = pr.gh_created_at
+        old_head, new_head = "oldhead6", "newhead6"
+        self._seed_old_head_state(pr, old_head)
+        t_push = created + timezone.timedelta(hours=2)
+        pr.head_sha = new_head
+        pr.gh_updated_at = t_push
+        pr.save(update_fields=["head_sha", "gh_updated_at"])
+
+        rebuild_pr_revisions(pr)
+        new_rev = PRRevision.objects.get(pull_request=pr, head_sha=new_head)
+        self.assertEqual(new_rev.from_ts, t_push)  # dated from the push, no CI yet
+
+        # CI finally runs for the current head (e.g. a maintainer approved the fork run).
+        t_ci = created + timezone.timedelta(hours=5)
+        CommitCheckRun.objects.create(
+            repository=self.repo,
+            github_node_id="CR_new6",
+            head_sha=new_head,
+            name="ci",
+            status="COMPLETED",
+            conclusion="SUCCESS",
+            details_url=None,
+            external_id=None,
+            gh_started_at=t_ci,
+            gh_completed_at=t_ci + timezone.timedelta(minutes=5),
+        )
+
+        rebuild_pr_revisions(pr)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts"))
+        self.assertEqual([r.head_sha for r in revs], [old_head, new_head])
+        # No gap: the old-head window now closes exactly where the new-head window opens.
+        self.assertEqual(revs[0].to_ts, t_ci)
+        self.assertEqual(revs[1].from_ts, t_ci)
+        self.assertIsNone(revs[1].to_ts)
+
+        # Converged: a further rebuild changes nothing.
+        state = PRRevisionBuildState.objects.get(pull_request=pr)
+        version_after = state.revision_version
+        res = rebuild_pr_revisions(pr)
+        self.assertEqual(res.strategy, "noop")
+        state.refresh_from_db()
+        self.assertEqual(state.revision_version, version_after)
+
     def test_build_state_updated_on_full_rebuild(self) -> None:
         pr = self._mk_pr(9)
         created = pr.gh_created_at


### PR DESCRIPTION
A PR could be silently dropped from the queue when its head advanced via a plain commit push whose CI never ran e.g. a fork PR whose workflows are path-filtered out (observed on `leanprover-community/mathlib4#40601`).

The revision builder (`rebuild_pr_revisions`) derived a PR's head history **only** from `HEAD_FORCE_PUSHED` timeline events and CI-bearing commits, never from `pr.head_sha` directly (except a no-CI seed fallback). So a normal push with no force-push event and no CI was invisible to it, leaving it pinned to the previous, failed commit. The two halves of the system then disagreed:

- queue-window builder → evaluated CI against the stale `PRRevision` head (failed `Build`) → **off-queue**
- snapshot candidate path → evaluated `pr.head_sha` (missing CI → eligible under `no_required_failures`) → **on-queue** (`in_Queue=True`)

Under the repo's configured `no_required_failures` gating, the PR *should* be on the queue, so "off-queue" was a bug.

Changes:

`qb_site/analyzer/services/revisions.py`:
- `_ensure_current_head_window`: when `pr.head_sha` is ahead of every derived head, close the trailing window and open one for the real current head. No-op when the head is unset or already matches (so normal force-push / CI / brand-new PRs are untouched).
- `head_mismatch` guard: force a rebuild past the noop short-circuit when the trailing revision head ≠ `pr.head_sha` (a no-CI push advances no time-based signal, so the noop guard would otherwise skip it).
- Append-safety guard: append only when the immutable prefix still matches what we re-derive; otherwise fall back to a full rebuild: prevents a revision coverage gap when a synthetic window is later superseded by a CI-derived one.
- Boundary timestamp (`_current_head_change_ts`): GitHub exposes no push time, so we use `gh_updated_at` (push-time proxy, an upper bound → conservatively under-counts queue time), reused for stable continuations; reverts use the re-push time. This affects only queue-*time* accounting, never the on/off-queue result.

Edge cases & limitations (see design decision 047):
- Intermediate transient heads (A→B→C with B having no CI/event) aren't recorded: no signal or timestamp exists for B; the current head C is tracked correctly.
- `timeline_backfill_done` precondition still short-circuits before the head check.
- Relies on `pr.head_sha` being correct (sound for live syncs; the newer-wins guard is archive-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)