### PR TITLE
fix(analyzer): triage CI-gating classification and legacy parity fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
         run: |
           uv run python -m queueboard.test_process
 
+      - name: Test PR state classification
+        run: |
+          uv run python -m queueboard.classify_pr_state
+
+      - name: Test PR state evolution
+        run: |
+          uv run python -m queueboard.test_state_evolution
+
       - name: Run dashboard_data in test/newtest
         working-directory: test/newtest
         run: |

--- a/qb_site/analyzer/services/ci_evaluation.py
+++ b/qb_site/analyzer/services/ci_evaluation.py
@@ -172,8 +172,13 @@ def _evaluate_required_contexts(
     any_missing = False
 
     for ctx_name in required_contexts:
-        cr_matches = [cr for cr in check_runs if ctx_name in (cr.get("name") or "").lower()]
-        sc_matches = [sc for sc in status_contexts if ctx_name in (sc.get("name") or "").lower()]
+        fragment = (ctx_name or "").strip().lower()
+        if not fragment:
+            # An empty/blank required context must not match every check (``"" in name`` is always
+            # True). Skip it, mirroring the guard in queueboard_snapshot._context_name_matches.
+            continue
+        cr_matches = [cr for cr in check_runs if fragment in (cr.get("name") or "").lower()]
+        sc_matches = [sc for sc in status_contexts if fragment in (sc.get("name") or "").lower()]
         status = context_aggregate_status(cr_matches, sc_matches)
         if status == "pass":
             continue

--- a/qb_site/analyzer/services/queueboard_snapshot.py
+++ b/qb_site/analyzer/services/queueboard_snapshot.py
@@ -312,16 +312,26 @@ def _label_url(repo: Repository, name: str) -> str:
 
 
 def _classify_pr_status(
-    *, label_names: set[str], ci_status: CIStatus, is_draft: bool, head_repo_owner: str, repo_owner: str
+    *,
+    label_names: set[str],
+    ci_status: CIStatus,
+    is_draft: bool,
+    head_repo_owner: str,
+    repo_owner: str,
+    ci_gating_mode: str | None = None,
 ) -> str:
-    """Use legacy classify_pr_state logic."""
+    """Use legacy classify_pr_state logic.
+
+    ``ci_gating_mode`` is the rule set's effective CI gating mode; it keeps the triage
+    classification consistent with queue eligibility (e.g. under 'no_required_failures' a
+    missing/running required job does not mark the PR as work in progress)."""
     kinds = []
     for name in label_names:
         if name in label_categorisation_rules:
             kinds.append(label_categorisation_rules[name])
     from_fork = head_repo_owner.lower() != repo_owner.lower()
     state = PRState(kinds, ci_status, is_draft, from_fork)
-    status = determine_PR_status(datetime.now(timezone.utc), state)
+    status = determine_PR_status(datetime.now(timezone.utc), state, ci_gating_mode)
     return status.value
 
 
@@ -365,6 +375,7 @@ class QueueboardSnapshotBuilder:
         generated_at = datetime.now(timezone.utc)
         effective_rule_set = rule_set or self._default_rule_set(repository)
         required_contexts = self._required_contexts(effective_rule_set)
+        ci_gating_mode = effective_rule_set.effective_ci_gating_mode() if effective_rule_set else None
         need_ci_data = bool(required_contexts)
         pr_qs = (
             PullRequest.objects.filter(repository=repository, state=PullRequestState.OPEN)
@@ -470,6 +481,7 @@ class QueueboardSnapshotBuilder:
                 is_draft=pr.is_draft,
                 head_repo_owner=pr.head_repo_owner_login,
                 repo_owner=repository.owner,
+                ci_gating_mode=ci_gating_mode,
             )
             entry = self._build_pr_entry(
                 pr,

--- a/qb_site/analyzer/services/queueboard_snapshot.py
+++ b/qb_site/analyzer/services/queueboard_snapshot.py
@@ -286,27 +286,6 @@ def _ci_status_for_pr(
     return (required_status, ci_ok)
 
 
-def _forbidden_queue_labels(default_branch: str) -> set[str]:
-    base = {
-        "blocked-by-other-pr",
-        "blocked-by-core-pr",
-        "blocked-by-batt-pr",
-        "blocked-by-qq-pr",
-        "awaiting-ci",
-        "awaiting-author",
-        "awaiting-zulip",
-        "please-adopt",
-        "help-wanted",
-        "wip",
-        "delegated",
-        "auto-merge-after-ci",
-        "ready-to-merge",
-    }
-    # Align with legacy queue filter: queue only considers default branch PRs.
-    _ = default_branch  # placeholder for future branch-specific rules
-    return base
-
-
 def _label_url(repo: Repository, name: str) -> str:
     return f"https://github.com/{repo.owner}/{repo.name}/labels/{name}"
 

--- a/qb_site/analyzer/services/queueboard_snapshot.py
+++ b/qb_site/analyzer/services/queueboard_snapshot.py
@@ -564,15 +564,14 @@ class QueueboardSnapshotBuilder:
                     stale_ready_to_merge.append(pr.number)
             if "delegated" in label_names_lc and pr.gh_updated_at < stale_ready_threshold and not pr.is_draft:
                 stale_delegated.append(pr.number)
-            if "maintainer-merge" in label_names_lc and not any(
-                lbl in label_names_lc for lbl in ("ready-to-merge", "auto-merge-after-ci")
-            ):
-                # NOTE(parity): legacy AllMaintainerMerge only includes PRs older than a day;
-                # we currently keep all maintainer-merge PRs here and use staleness only for the stale subset.
+            if "maintainer-merge" in label_names_lc and "ready-to-merge" not in label_names_lc and not pr.is_draft:
+                # Parity with legacy: AllMaintainerMerge is all *non-draft* maintainer-merge PRs minus
+                # ready-to-merge; it is NOT age-gated (StaleMaintainerMerge is the >1-day-old subset).
+                # Legacy excludes only ready-to-merge here, not auto-merge-after-CI.
                 all_maintainer_merge.append(pr.number)
                 if pr.gh_updated_at < stale_ready_threshold:
                     stale_maintainer_merge.append(pr.number)
-            if "new-contributor" in label_names_lc and pr.gh_updated_at < stale_new_contrib_threshold:
+            if "new-contributor" in label_names_lc and pr.gh_updated_at < stale_new_contrib_threshold and not pr.is_draft:
                 stale_new_contributor.append(pr.number)
 
         dashboards = {

--- a/qb_site/analyzer/tests/services/test_ci_evaluation.py
+++ b/qb_site/analyzer/tests/services/test_ci_evaluation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from django.test import SimpleTestCase
+
+from analyzer.services.ci_evaluation import _evaluate_required_contexts
+
+
+def _check_run(name: str, conclusion: str) -> dict:
+    ts = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return {
+        "name": name,
+        "status": "COMPLETED",
+        "conclusion": conclusion,
+        "head_sha": "sha",
+        "gh_started_at": ts,
+        "gh_completed_at": ts,
+    }
+
+
+class EvaluateRequiredContextsTests(SimpleTestCase):
+    def test_empty_required_fragment_is_ignored(self):
+        passing = [_check_run("lint", "SUCCESS")]
+        # An empty/blank required context must not match every check (``"" in name`` is always True);
+        # it is skipped rather than collapsing the evaluation to "aggregate of all checks".
+        self.assertEqual(_evaluate_required_contexts(["lint"], passing, []), "pass")
+        self.assertEqual(_evaluate_required_contexts(["", "   "], passing, []), "pass")
+
+    def test_blank_fragment_does_not_mask_a_real_failure(self):
+        runs = [_check_run("lint", "SUCCESS"), _check_run("build", "FAILURE")]
+        self.assertEqual(_evaluate_required_contexts(["build", ""], runs, []), "fail")
+
+    def test_fragment_is_matched_case_insensitively(self):
+        runs = [_check_run("Lint style", "SUCCESS")]
+        self.assertEqual(_evaluate_required_contexts(["Lint style"], runs, []), "pass")

--- a/qb_site/analyzer/tests/test_queueboard_snapshot.py
+++ b/qb_site/analyzer/tests/test_queueboard_snapshot.py
@@ -500,6 +500,34 @@ class QueueboardSnapshotBuilderTests(TestCase):
         snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
         self.assertNotIn(pr.number, snapshot["lists"]["dashboards"]["Queue"])
 
+    def test_maintainer_merge_dashboards_parity(self):
+        # Legacy AllMaintainerMerge = all NON-DRAFT maintainer-merge PRs minus ready-to-merge,
+        # NOT age-gated and NOT excluding auto-merge-after-CI.
+        a = self._make_pr(70, labels=("maintainer-merge",))
+        b = self._make_pr(71, labels=("maintainer-merge", "auto-merge-after-CI"))
+        c = self._make_pr(72, labels=("maintainer-merge", "ready-to-merge"))
+        d = self._make_pr(73, is_draft=True, labels=("maintainer-merge",))
+        rule_set = QueueRuleSet.objects.create(repository=self.repo, version=1, require_ci_success=False)
+
+        snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
+        all_mm = snapshot["lists"]["dashboards"]["AllMaintainerMerge"]
+        self.assertIn(a.number, all_mm)
+        self.assertIn(b.number, all_mm)  # auto-merge-after-CI is NOT excluded (legacy parity)
+        self.assertNotIn(c.number, all_mm)  # ready-to-merge is excluded
+        self.assertNotIn(d.number, all_mm)  # draft is excluded (legacy operates on non-draft PRs)
+
+    def test_stale_new_contributor_excludes_drafts(self):
+        # gh_updated_at is set to a fixed past date in _make_pr, so these are "stale" vs the live
+        # 7-day threshold. Legacy StaleNewContributor operates on non-draft PRs only.
+        nondraft = self._make_pr(74, labels=("new-contributor",))
+        draft = self._make_pr(75, is_draft=True, labels=("new-contributor",))
+        rule_set = QueueRuleSet.objects.create(repository=self.repo, version=1, require_ci_success=False)
+
+        snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
+        stale_nc = snapshot["lists"]["dashboards"]["StaleNewContributor"]
+        self.assertIn(nondraft.number, stale_nc)
+        self.assertNotIn(draft.number, stale_nc)  # draft excluded (legacy parity)
+
     def test_no_required_failures_allows_missing_context_on_queue(self):
         pr = self._make_pr(57, author=self.user, labels=("t-analysis",))
         rule_set = QueueRuleSet.objects.create(

--- a/qb_site/analyzer/tests/test_queueboard_snapshot.py
+++ b/qb_site/analyzer/tests/test_queueboard_snapshot.py
@@ -513,6 +513,9 @@ class QueueboardSnapshotBuilderTests(TestCase):
         snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
         self.assertEqual(snapshot["prs"][pr.number]["ci_status"], "missing")
         self.assertIn(pr.number, snapshot["lists"]["dashboards"]["Queue"])
+        # Under 'no_required_failures', a missing required context must not be classified as
+        # work-in-progress: the triage status stays consistent with queue eligibility.
+        self.assertEqual(snapshot["prs"][pr.number]["pr_status"], "AwaitingReview")
 
     def test_no_required_failures_allows_running_context_on_queue(self):
         pr = self._make_pr(58, author=self.user, labels=("t-analysis",))
@@ -528,6 +531,8 @@ class QueueboardSnapshotBuilderTests(TestCase):
         snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
         self.assertEqual(snapshot["prs"][pr.number]["ci_status"], "running")
         self.assertIn(pr.number, snapshot["lists"]["dashboards"]["Queue"])
+        # A still-running required context is likewise tolerated under 'no_required_failures'.
+        self.assertEqual(snapshot["prs"][pr.number]["pr_status"], "AwaitingReview")
 
     def test_no_required_failures_still_blocks_observed_failure(self):
         pr = self._make_pr(59, author=self.user, labels=("t-analysis",))
@@ -543,6 +548,8 @@ class QueueboardSnapshotBuilderTests(TestCase):
         snapshot = QueueboardSnapshotBuilder(chunk_size=1).build(self.repo, rule_set=rule_set)
         self.assertEqual(snapshot["prs"][pr.number]["ci_status"], "fail")
         self.assertNotIn(pr.number, snapshot["lists"]["dashboards"]["Queue"])
+        # An actual required-context failure still marks the PR not ready, even under this mode.
+        self.assertEqual(snapshot["prs"][pr.number]["pr_status"], "NotReady")
 
     def test_queue_includes_fail_inessential_when_required_contexts_pass(self):
         pr = self._make_pr(56, author=self.user, labels=("t-analysis",))

--- a/src/queueboard/classify_pr_state.py
+++ b/src/queueboard/classify_pr_state.py
@@ -157,6 +157,31 @@ class PRStatus(StrEnum):
         }.get(value)
 
 
+# CI gating mode string matching analyzer.QueueRuleSet.CIGatingMode.NO_REQUIRED_FAILURES.
+# Kept as a bare string so this standalone module need not import the Django model.
+CI_GATING_NO_REQUIRED_FAILURES = "no_required_failures"
+
+
+def ci_status_blocks_readiness(ci: CIStatus, ci_gating_mode: str | None) -> bool:
+    """Whether a CI status should mark a PR as "not ready", given the repo's CI gating mode.
+
+    This mirrors the queue-eligibility logic in the analyzer's snapshot builder
+    (``_ci_status_is_queue_eligible``), so the triage classification and the actual queue
+    membership stay consistent about CI:
+
+    - ``"no_required_failures"``: only an *actual failure* of a required job blocks. A
+      missing or still-running required job is tolerated (the PR can sit on the queue),
+      so it must not be classified as work-in-progress on that basis alone.
+    - any other mode, including no explicit gating (``None``): require passing CI, i.e. any
+      non-passing status (failing, inessential-failing, missing or running) blocks. This is
+      the historical behaviour assumed by the legacy file-based dashboard pipeline and the
+      state-evolution replay, neither of which carry a gating mode.
+    """
+    if ci_gating_mode == CI_GATING_NO_REQUIRED_FAILURES:
+        return ci == CIStatus.Fail
+    return ci in [CIStatus.Fail, CIStatus.FailInessential, CIStatus.Missing, CIStatus.Running]
+
+
 def label_to_prstatus(label: LabelKind) -> PRStatus:
     return {
         LabelKind.WIP: PRStatus.NotReady,
@@ -172,24 +197,29 @@ def label_to_prstatus(label: LabelKind) -> PRStatus:
     }[label]
 
 
-def determine_PR_status(date: datetime, state: PRState) -> PRStatus:
-    """Determine a PR's status from its state
-    'date' is necessary as the interpretation of the awaiting-review label changes over time"""
+def determine_PR_status(date: datetime, state: PRState, ci_gating_mode: str | None = None) -> PRStatus:
+    """Determine a PR's status from its state.
+
+    'date' is necessary as the interpretation of the awaiting-review label changes over time.
+    'ci_gating_mode' is the repository's effective CI gating mode (see
+    ``ci_status_blocks_readiness``); when ``None`` (the default, used by the legacy
+    file-based pipeline and state-evolution replay) any non-passing CI marks a PR not ready."""
     if not state.from_fork:
         return PRStatus.NotFromFork
 
-    # Failing (or missing or running) CI counts like the WIP label.
-    # In particular, it is compared against other labels.
-    # Note: some CI failures are "inessential" (i.e., some infra job failing for unrelated reasons).
-    # Always treating this as "fine" seems wrong (for some infra PRs, it means "there's a bug somewhere").
-    # Instead, we treat it like a failing job, but have an extra dashboard exposing these
-    # (so one can take a look quickly).
-    if state.draft or state.ci in [CIStatus.Fail, CIStatus.FailInessential, CIStatus.Missing]:
+    # Whether the CI state counts like a WIP label, comparing against other labels.
+    # What counts as "blocking" depends on the repo's CI gating mode: under
+    # 'no_required_failures' a missing or running required job is tolerated (and so must not,
+    # on its own, mark the PR as work in progress), whereas the default strict mode treats any
+    # non-passing CI (failing, inessential-failing, missing or running) as not ready.
+    # Note: some CI failures are "inessential" (i.e., some infra job failing for unrelated
+    # reasons). Under strict gating we still treat this like a failing job (but expose them in
+    # an extra dashboard); under 'no_required_failures' it is tolerated like a non-failure.
+    if state.draft or ci_status_blocks_readiness(state.ci, ci_gating_mode):
         notready = True
-    # The 'awaiting-CI' label or 'running' CI also mark a PR as 'not ready' yet:
-    # this ought to be a transient state; when a CI run completes, the PR status
-    # (in hindsight) will be set accordingly.
-    elif state.ci == CIStatus.Running or LabelKind.AwaitingCI in state.labels:
+    # The 'awaiting-CI' label always marks a PR as 'not ready' yet, independently of the CI
+    # gating mode: it is an explicit author/maintainer signal rather than a CI rollup.
+    elif LabelKind.AwaitingCI in state.labels:
         notready = True
     else:
         notready = False
@@ -375,5 +405,54 @@ def test_determine_status() -> None:
     check([LabelKind.Bors, LabelKind.Bors], PRStatus.AwaitingBors)
 
 
+def test_ci_gating_mode() -> None:
+    """The CI gating mode controls when CI marks a PR as 'not ready'.
+
+    Self-contained (does not rely on the ``with_labels*`` helpers, which build ``from_fork=False``
+    states), so it can run independently of ``test_determine_status``."""
+    date = datetime(2024, 8, 1, tzinfo=tz.tzutc())
+    nrf = CI_GATING_NO_REQUIRED_FAILURES
+
+    def st(labels: List[LabelKind], ci: CIStatus, draft: bool = False) -> PRState:
+        return PRState(labels, ci, draft, from_fork=True)
+
+    def check(state: PRState, mode: str | None, expected: PRStatus) -> None:
+        actual = determine_PR_status(date, state, mode)
+        assert expected == actual, f"expected {expected} from state {state} (mode={mode}), got {actual}"
+
+    # Unit-level coverage of the blocking predicate itself.
+    assert ci_status_blocks_readiness(CIStatus.Fail, nrf)
+    assert not ci_status_blocks_readiness(CIStatus.Missing, nrf)
+    assert not ci_status_blocks_readiness(CIStatus.Running, nrf)
+    assert not ci_status_blocks_readiness(CIStatus.FailInessential, nrf)
+    assert not ci_status_blocks_readiness(CIStatus.Pass, nrf)
+    for ci in [CIStatus.Fail, CIStatus.FailInessential, CIStatus.Missing, CIStatus.Running]:
+        assert ci_status_blocks_readiness(ci, None), ci
+    assert not ci_status_blocks_readiness(CIStatus.Pass, None)
+
+    # Under 'no_required_failures': missing / running / passing CI no longer forces NotReady;
+    # the underlying labels decide the status.
+    check(st([], CIStatus.Missing), nrf, PRStatus.AwaitingReview)
+    check(st([], CIStatus.Running), nrf, PRStatus.AwaitingReview)
+    check(st([], CIStatus.Pass), nrf, PRStatus.AwaitingReview)
+    check(st([LabelKind.MergeConflict], CIStatus.Missing), nrf, PRStatus.MergeConflict)
+    check(st([LabelKind.Author], CIStatus.Running), nrf, PRStatus.AwaitingAuthor)
+    check(st([LabelKind.Bors], CIStatus.Missing), nrf, PRStatus.AwaitingBors)
+    # An actual required-job failure still marks the PR not ready, even under this mode.
+    check(st([], CIStatus.Fail), nrf, PRStatus.NotReady)
+    check(st([LabelKind.MergeConflict], CIStatus.Fail), nrf, PRStatus.NotReady)
+    # The explicit awaiting-CI label and draft state are independent of CI gating.
+    check(st([LabelKind.AwaitingCI], CIStatus.Pass), nrf, PRStatus.NotReady)
+    check(st([], CIStatus.Missing, draft=True), nrf, PRStatus.NotReady)
+
+    # The default (None) mode preserves the strict legacy behaviour: any non-passing CI blocks.
+    check(st([], CIStatus.Missing), None, PRStatus.NotReady)
+    check(st([], CIStatus.Running), None, PRStatus.NotReady)
+    check(st([LabelKind.MergeConflict], CIStatus.Missing), None, PRStatus.NotReady)
+    check(st([], CIStatus.Pass), None, PRStatus.AwaitingReview)
+    print("test_ci_gating_mode: all tests pass")
+
+
 if __name__ == "__main__":
+    test_ci_gating_mode()
     test_determine_status()

--- a/src/queueboard/classify_pr_state.py
+++ b/src/queueboard/classify_pr_state.py
@@ -44,16 +44,19 @@ class PRState(NamedTuple):
 
     @staticmethod
     def with_labels(labels: List[LabelKind]):
-        """Create a PR state with just these labels, passing CI and ready for review"""
-        return PRState(labels, CIStatus.Pass, False, False)
+        """Create a PR state with just these labels, passing CI and ready for review.
+
+        The state is from a fork (``from_fork=True``): otherwise it would classify as
+        ``NotFromFork`` regardless of labels/CI, which is not what these helpers model."""
+        return PRState(labels, CIStatus.Pass, False, True)
 
     @staticmethod
     def with_labels_and_ci(labels: List[LabelKind], ci: CIStatus):
-        return PRState(labels, ci, False, False)
+        return PRState(labels, ci, False, True)
 
     @staticmethod
     def with_labels_ci_draft(labels: List[LabelKind], ci: CIStatus, is_draft: bool):
-        return PRState(labels, ci, is_draft, False)
+        return PRState(labels, ci, is_draft, True)
 
 
 # Map a label name (as a string) to a `LabelKind`.
@@ -317,9 +320,9 @@ def test_determine_status() -> None:
     # Tests for handling draft and CI state.
     # These take precedence over any other labels.
     # Failing CI marks a PR as "not ready".
-    check2(PRState([], CIStatus.Pass, True, False), PRStatus.NotReady)
-    check2(PRState([], CIStatus.Fail, False, False), PRStatus.NotReady)
-    check2(PRState([], CIStatus.Fail, True, False), PRStatus.NotReady)
+    check2(PRState([], CIStatus.Pass, True, True), PRStatus.NotReady)
+    check2(PRState([], CIStatus.Fail, False, True), PRStatus.NotReady)
+    check2(PRState([], CIStatus.Fail, True, True), PRStatus.NotReady)
     # Running CI is treated as "failing" for the purposes of our classification.
     # The awaiting-CI label has the same effect as a "running" CI state.
     check2(PRState.with_labels_and_ci([], CIStatus.Running), PRStatus.NotReady)

--- a/src/queueboard/compute_dashboard_prs.py
+++ b/src/queueboard/compute_dashboard_prs.py
@@ -722,7 +722,7 @@ def determine_pr_dashboards(
     prs_to_list[Dashboard.OtherBase] = [pr for pr in nondraft_PRs if base_branch[pr.number] != "master"]
     prs_to_list[Dashboard.NotFromFork] = prs_not_from_fork
 
-    prs_to_list[Dashboard.NeedsHelp] = prs_with_any_label(nondraft_PRs, ["help-wanted", "please_adopt"])
+    prs_to_list[Dashboard.NeedsHelp] = prs_with_any_label(nondraft_PRs, ["help-wanted", "please-adopt"])
     prs_to_list[Dashboard.NeedsDecision] = prs_with_label(nondraft_PRs, "awaiting-zulip")
 
     # Compute all PRs on the review queue (and well as several sub-filters).

--- a/src/queueboard/compute_dashboard_prs.py
+++ b/src/queueboard/compute_dashboard_prs.py
@@ -612,7 +612,7 @@ def gather_pr_statistics(
         # We should guard number_percent(...) or rephrase to skip the percentage when total == 0.
         PRStatus.MergeConflict: f"have a merge conflict: among these, <b>{number_percent(len(justmerge_prs), number_prs[PRStatus.MergeConflict])}</b> would be ready for review otherwise: {link_to(Dashboard.NeedsMerge, 'these')}",
         PRStatus.Contradictory: f"have contradictory labels ({link_to(Dashboard.ContradictoryLabels)})",
-        PRStatus.NotReady: "are marked as draft or work in progress",
+        PRStatus.NotReady: "are marked as draft or work in progress, or do not (yet) pass CI",
     }
     assert set(instatus.keys()) == set(statusses)
     color = {

--- a/src/queueboard/dashboard.py
+++ b/src/queueboard/dashboard.py
@@ -723,7 +723,7 @@ def write_on_the_queue_page(
             PRStatus.Delegated: ("is", "delegated"),
             PRStatus.HelpWanted: ("is", "looking for help"),
             PRStatus.Blocked: ("is", "blocked on another PR"),
-            PRStatus.NotReady: ("is", "labelled WIP or marked draft"),
+            PRStatus.NotReady: ("is", "labelled WIP, marked draft, or not passing CI"),
             PRStatus.NotFromFork: ("is", "opened from a branch in the main mathlib repo (not a fork)"),
             PRStatus.Contradictory: ("has", "contradictory labels"),
             PRStatus.Closed: ("is", "closed (so shouldn't appear in this list)"),

--- a/src/queueboard/test_state_evolution.py
+++ b/src/queueboard/test_state_evolution.py
@@ -50,7 +50,7 @@ def sep(n: int) -> datetime:
 # These tests are just some basic smoketests and not exhaustive.
 def test_determine_state_changes() -> None:
     def check(events: List[Event], expected: PRState) -> None:
-        initial = PRState([], CIStatus.Pass, False, False)
+        initial = PRState([], CIStatus.Pass, False, True)
         compute = determine_state_changes(datetime(2024, 7, 15, tzinfo=tz.tzutc()), initial, events)
         actual = compute[-1][1]
         assert expected == actual, f"expected PR state {expected} from events {events}, got {actual}"
@@ -124,7 +124,7 @@ def test_determine_state_changes() -> None:
 
 def test_total_queue_time() -> None:
     def check_basic(created: datetime, now: datetime, events: List[Event], expected: relativedelta) -> None:
-        ((_, wait), _) = total_queue_time_inner(now, Metadata(created, events, False, False))
+        ((_, wait), _) = total_queue_time_inner(now, Metadata(created, events, False, True))
         assert wait == expected, f"basic test failed: expected total time of {expected} in review, obtained {wait} instead"
 
     def check_with_initial(now: datetime, state: Metadata, expected: relativedelta) -> None:
@@ -254,7 +254,7 @@ def test_total_queue_time() -> None:
     # Adapted from PR 16666: created in draft state.
     events = [Event.add_label(sep(10), "t-meta"), Event.undraft(sep(10)), Event.add_label(sep(29), "ready-to-merge")]
     check_basic(sep(1), sep(30), events, relativedelta(days=28))
-    check_with_initial(sep(30), Metadata(sep(1), events, True, False), relativedelta(days=19))
+    check_with_initial(sep(30), Metadata(sep(1), events, True, True), relativedelta(days=19))
 
     # Minimised from PR 14269
     events = [
@@ -264,7 +264,7 @@ def test_total_queue_time() -> None:
         Event.add_label(july(1), "awaiting-author"),
         Event.remove_label(july(1), "awaiting-author"),
     ]
-    check_with_initial(sep(30), Metadata(june(28), events, False, False), relativedelta(days=2))
+    check_with_initial(sep(30), Metadata(june(28), events, False, True), relativedelta(days=2))
 
     # Subtle detail: the awaiting-review flag is not removed on July 9th (for these data),
     # so a new assessment of the state only happens at the later label changes.
@@ -289,7 +289,7 @@ def test_total_queue_time() -> None:
         Event.remove_label(sep(20), "help-wanted"),
         Event.add_label(sep(22), "awaiting-author"),
     ]
-    check_with_initial(sep(25), Metadata(june(29), events, False, False), relativedelta(days=4))
+    check_with_initial(sep(25), Metadata(june(29), events, False, True), relativedelta(days=4))
 
     events = [
         Event.add_label(june(29), "awaiting-review-DONT-USE"),
@@ -314,7 +314,7 @@ def test_total_queue_time() -> None:
         Event.remove_label(sep(23), "awaiting-author"),
         # on the queue now
     ]
-    check_with_initial(sep(27), Metadata(june(29), events, False, False), relativedelta(days=8))
+    check_with_initial(sep(27), Metadata(june(29), events, False, True), relativedelta(days=8))
 
     events = [
         Event.draft(sep(3)),
@@ -324,7 +324,7 @@ def test_total_queue_time() -> None:
         Event.add_label(sep(29), "ready-to-merge"),
     ]
     # total review time windows: sep 1-3, sep 10-15: 7 days
-    check_with_initial(sep(30), Metadata(sep(1), events, False, False), relativedelta(days=7))
+    check_with_initial(sep(30), Metadata(sep(1), events, False, True), relativedelta(days=7))
 
 
 # Some basic tests for last_status_update and first time on the queue.
@@ -342,14 +342,14 @@ def test_last_status_update():
     def check_basic(
         created: datetime, now: datetime, events: List[Event], expected: Tuple[datetime, relativedelta, PRStatus]
     ) -> None:
-        check_with_initial(now, Metadata(created, events, False, False), expected)
+        check_with_initial(now, Metadata(created, events, False, True), expected)
 
     def check_first(metadata: Metadata, expected: datetime) -> None:
         actual = first_on_queue_inner(metadata)
         assert actual == expected, f"expect first time on the queue of {expected}, obtained {actual} instead"
 
     def check_first_basic(created: datetime, events: List[Event], expected: datetime) -> None:
-        check_first(Metadata(created, events, False, False), expected)
+        check_first(Metadata(created, events, False, True), expected)
 
     events = [
         Event.add_label(sep(10), "blocked-by-other-PR"),
@@ -391,7 +391,7 @@ def test_last_status_update():
     # Adapted from PR 16666: created in draft state.
     events = [Event.add_label(sep(10), "t-meta"), Event.undraft(sep(11)), Event.add_label(sep(25), "ready-to-merge")]
     check_basic(sep(1), sep(30), events, (sep(25), relativedelta(days=5), PRStatus.AwaitingBors))
-    check_with_initial(sep(28), Metadata(sep(1), events, True, False), (sep(25), relativedelta(days=3), PRStatus.AwaitingBors))
+    check_with_initial(sep(28), Metadata(sep(1), events, True, True), (sep(25), relativedelta(days=3), PRStatus.AwaitingBors))
     check_first_basic(sep(9), events, sep(9))
 
     events = [
@@ -401,7 +401,7 @@ def test_last_status_update():
         Event.draft(sep(15)),
         Event.add_label(sep(29), "WIP-to-merge"),
     ]
-    check_with_initial(sep(30), Metadata(sep(1), events, False, False), (sep(29), relativedelta(days=1), PRStatus.NotReady))
+    check_with_initial(sep(30), Metadata(sep(1), events, False, True), (sep(29), relativedelta(days=1), PRStatus.NotReady))
     check_first_basic(sep(3), events, sep(10))
     # Minimised from PR 14269
     events = [
@@ -412,7 +412,7 @@ def test_last_status_update():
         Event.remove_label(july(1), "awaiting-author"),
     ]
     check_with_initial(
-        sep(30), Metadata(june(28), events, False, False), (july(1), relativedelta(months=2, days=29), PRStatus.AwaitingAuthor)
+        sep(30), Metadata(june(28), events, False, True), (july(1), relativedelta(months=2, days=29), PRStatus.AwaitingAuthor)
     )
     check_first_basic(june(29), events, june(29))
     events = [
@@ -422,7 +422,7 @@ def test_last_status_update():
         Event.add_remove_labels(july(1), ["awaiting-author"], ["awaiting-author"]),
     ]
     check_with_initial(
-        sep(30), Metadata(june(28), events, False, False), (july(1), relativedelta(months=2, days=29), PRStatus.AwaitingAuthor)
+        sep(30), Metadata(june(28), events, False, True), (july(1), relativedelta(months=2, days=29), PRStatus.AwaitingAuthor)
     )
     check_first_basic(june(28), events, june(29))
 
@@ -441,7 +441,7 @@ def test_last_status_update():
         Event.remove_label(july(13), "WIP"),
     ]
     check_with_initial(
-        aug(30), Metadata(june(28), events, False, False), (july(13), relativedelta(months=1, days=17), PRStatus.AwaitingReview)
+        aug(30), Metadata(june(28), events, False, True), (july(13), relativedelta(months=1, days=17), PRStatus.AwaitingReview)
     )
     check_first_basic(june(28), events, june(29))
 
@@ -454,7 +454,7 @@ def test_last_status_update():
         Event.remove_label(aug(13), "WIP"),
     ]
     check_with_initial(
-        aug(30), Metadata(june(27), events, False, False), (aug(13), relativedelta(days=17), PRStatus.AwaitingReview)
+        aug(30), Metadata(june(27), events, False, True), (aug(13), relativedelta(days=17), PRStatus.AwaitingReview)
     )
     check_first_basic(june(27), events, june(29))
 
@@ -473,7 +473,7 @@ def test_last_status_update():
         Event.add_label(july(13), "help-wanted"),
         Event.add_label(aug(8), "awaiting-author"),
     ]
-    check_with_initial(aug(30), Metadata(june(28), events, False, False), (aug(8), relativedelta(days=22), PRStatus.HelpWanted))
+    check_with_initial(aug(30), Metadata(june(28), events, False, True), (aug(8), relativedelta(days=22), PRStatus.HelpWanted))
     check_first_basic(june(28), events, june(29))
 
     events = [
@@ -495,7 +495,7 @@ def test_last_status_update():
         Event.remove_label(sep(23), "awaiting-author"),
     ]
     check_with_initial(
-        sep(30), Metadata(june(28), events, False, False), (sep(23), relativedelta(days=7), PRStatus.AwaitingReview)
+        sep(30), Metadata(june(28), events, False, True), (sep(23), relativedelta(days=7), PRStatus.AwaitingReview)
     )
     check_first_basic(june(28), events, june(29))
 


### PR DESCRIPTION
The triage dashboard classified a PR as "draft or work in progress" (NotReady) whenever its CI rollup was missing, failing, or running, which predates per-ruleset CI gating. Under the `no_required_failures` mode a missing or still-running required job keeps a PR queue-eligible, but `determine_PR_status` still treated it as not-ready, so the legacy dashboard mass-classified queue-eligible PRs as WIP and emptied out the AwaitingReview/MergeConflict/etc. buckets. This threads the effective gating mode into `determine_PR_status` via a new `ci_status_blocks_readiness()` helper that mirrors queue eligibility: under `no_required_failures` only an actual failure blocks readiness, while every other mode (including the legacy file pipeline, which passes None) keeps the strict behaviour. On a production snapshot of leanprover-community/mathlib4, "draft or work in progress" drops from 1840 (67.7%) to 835 (30.7%), reclassifying 1011 PRs into AwaitingReview/MergeConflict/AwaitingAuthor.

It also closes several legacy-vs-snapshot parity gaps found in an audit: draft guards on the maintainer-merge and stale-new-contributor dashboards, an AllMaintainerMerge label-exclusion correction, a guard against empty required-context fragments in ci_evaluation (where `"" in name` always matches and would collapse the rollup), and a `please_adopt` -> `please-adopt` label typo in the NeedsHelp dashboard. Parity tests are added for these.

Finally, it fixes from_fork rot in the legacy state tests: #129 added an early NotFromFork return in `determine_PR_status`, but the fixtures built states with `from_fork=False`, so everything classified as NotFromFork and the suites either crashed or measured zero queue time. Neither suite ran in CI, so this went unnoticed. The factories/fixtures now set `from_fork=True` where appropriate, and `classify_pr_state` + `test_state_evolution` are added as CI steps so they cannot silently break again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
