### PR TITLE
fix(analyzer): heal revision-window gaps; stop FK-less CI attribution looping

### DIFF
--- a/docs/design-decisions/049-revision-gap-selfheal-and-fkless-ci-attribution.md
+++ b/docs/design-decisions/049-revision-gap-selfheal-and-fkless-ci-attribution.md
@@ -1,0 +1,100 @@
+# Revision-Gap Self-Heal and FK-less CI Attribution
+
+Status: accepted. Builder self-heal extension + staleness-check fix landed with
+regression tests.
+
+## Context
+
+The analyzer's `AnalyzerConvergenceSnapshot.windows_stale` metric sat at a small,
+constant non-zero value for days on `mathlib4` (3 `(PR, ruleset)` pairs). The
+`analyzer.rebuild_queue_windows_sweep` task reported the same PRs as
+`prs_stale_ruleset` every run while rebuilding **zero** of them
+(`windows_rebuilt: 0`, `prs_rebuilt_stale_ruleset: []`) — a permanent stale loop.
+
+Investigation (PRs 38269, 21594, 20584) found two stacked defects:
+
+1. **Non-contiguous `PRRevision` windows (root cause).** Each affected PR had a
+   hole between two adjacent revision windows — one revision's `to_ts` strictly
+   before the next revision's `from_ts` (and, on 21594, out-of-order/overlapping
+   rows). All CI rows for every head were present in the DB; nothing was missing
+   from GitHub. The gaps were legacy data produced by a pre-048 builder that
+   dropped a head.
+
+   Design 048 established the contiguity invariant (`to_ts[i] == from_ts[i+1]`)
+   and a self-healing full rebuild, but the self-heal only triggered on a single
+   **malformed** window (`to_ts < from_ts`). A *gap or overlap* where each window
+   is individually valid was never detected, so — combined with the rebuild
+   `noop` short-circuit for closed/inactive PRs whose trailing head already
+   matches `pr.head_sha` — these rows re-noop forever and never heal. The builder
+   version (`PR_REVISION_BUILDER_VERSION`) was not bumped when 048 landed, so that
+   path did not force a rebuild either.
+
+2. **FK-less CI attribution treated as a defect (the loop).** Inside a revision
+   gap the queue-window builder cannot resolve a head SHA, so it computes
+   `ci_state="missing"`. That flips queue eligibility (under
+   `all_required_success`, missing ⇒ ineligible ⇒ the window closes as
+   `CI_FAILED`; under `no_required_failures`, missing ⇒ eligible ⇒ the window
+   opens as `CI_PASSED`). Because there is no CI row for the nonexistent head, the
+   flip is attributed to CI with both CI FKs null
+   (`_determine_ci_boundary_attribution` step 5).
+
+   The sweep's staleness predicate (`_is_ruleset_stale_for_pr`) and the
+   convergence collector both treated "CI `event_type` with both CI FKs null" as
+   an inconsistency requiring backfill. But the builder *legitimately* produces
+   that shape, and a rebuild reproduces it identically (`created=updated=deleted=0`),
+   so the window was flagged stale, "rebuilt" to the same bytes, and re-flagged on
+   the next sweep — forever.
+
+A FK-less CI attribution is also produced legitimately outside revision gaps:
+when CI rows for an old head are deleted by `syncer.expire_stale_ci_for_repo`
+(doc 038), a rebuild can no longer tie the flip to a surviving row.
+
+## Decision
+
+1. **Extend the design-048 self-heal to detect non-contiguity, not just malformed
+   windows.** `_revisions_need_recontiguation(pr)` returns True when persisted
+   rows (ordered by `from_ts`) violate the invariant: any malformed window
+   (`to_ts <= from_ts`), any gap/overlap (`to_ts[i] != from_ts[i+1]`), or a
+   non-final window with a null `to_ts`. `rebuild_pr_revisions` forces a full
+   rebuild when it returns True (before the `noop` short-circuit), so
+   `_normalize_windows` re-stitches contiguity. It is a no-op on
+   `_normalize_windows` output and therefore converges.
+
+2. **Stop treating FK-less CI attribution as stale.** Remove the
+   "CI `event_type` + both CI FKs null" clauses from the sweep prefilter, the
+   sweep's exact per-PR check, and the convergence `windows_stale` collector. A CI
+   `event_type` with null FKs is an accepted terminal state. Pre-migration windows
+   with `opened_by_event_type IS NULL` are still flagged (a rebuild repairs them).
+
+## Consequences
+
+- Gappy/overlapping legacy revision rows now heal on the next rebuild that visits
+  the PR, and the queue-window boundary at the former gap is re-derived against a
+  real head with real CI (typically a `HEAD_PUSHED` or FK-bearing CI boundary).
+- `windows_stale` no longer loops on legitimately FK-less CI windows. The genuine
+  "expired CI FK" case is already covered by `expire_stale_ci_for_repo` nulling
+  `windows_built_at` (doc 045 watermark path); a window-row-level signal is not
+  needed and was the source of the loop.
+- Detection cost: `_revisions_need_recontiguation` loads a PR's revision rows
+  (ordered `from_ts`, `to_ts` only) once per non-noop rebuild decision, replacing a
+  single `EXISTS` query. Revision counts per PR are small; acceptable.
+
+## Operational Notes
+
+- One-off recovery for the three known PRs was done by forcing a full revision
+  rebuild (set `PRRevisionBuildState.dirty_from_ts`), then
+  `rebuild_queue_windows_for_pr` + `record_queue_window_build_states`. No GitHub
+  fetch was needed — the CI data was already present.
+- The self-heal only repairs PRs that `rebuild_revisions_sweep` actually visits.
+  Long-closed PRs that the sweep no longer scans may need a one-off backfill pass
+  over PRs with gaps if full historical cleanup is desired.
+
+## Alternatives
+
+- *Introduce a distinct FK-less CI event type* (e.g. `CI_INVALIDATED`) and exclude
+  it from the staleness check while keeping `CI_PASSED`/`CI_FAILED ⇒ FK` as a
+  defect signal. More faithful data, but more invasive (new enum value, a data
+  relabel) and unnecessary once the revision-gap root cause is fixed.
+- *Bump `PR_REVISION_BUILDER_VERSION`* to force every PR through the normalizer
+  once. Broader one-time churn than the targeted contiguity self-heal; rejected in
+  favor of healing only the PRs that actually violate the invariant.

--- a/qb_site/analyzer/AGENTS.md
+++ b/qb_site/analyzer/AGENTS.md
@@ -26,6 +26,9 @@ docker compose exec -T web python qb_site/manage.py plan_ci_backfill --repo lean
 
 # Backfill reviewer opt-outs command
 docker compose exec -T web python qb_site/manage.py backfill_reviewer_opt_outs --dry-run
+
+# Audit PRRevision window contiguity (read-only; design decision 049)
+docker compose exec -T web python qb_site/manage.py audit_revision_contiguity --repo leanprover-community/mathlib4
 ```
 
 ## Task Surface

--- a/qb_site/analyzer/management/commands/audit_revision_contiguity.py
+++ b/qb_site/analyzer/management/commands/audit_revision_contiguity.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import itertools
+from datetime import datetime
+from typing import Iterable, Optional
+
+from django.core.management.base import BaseCommand, CommandError
+
+from analyzer.models import PRRevision
+from core.models import Repository
+
+
+def classify_revision_windows(windows: list[tuple[Optional[datetime], Optional[datetime]]]) -> set[str]:
+    """Return the set of contiguity-violation categories in a PR's revision windows.
+
+    ``windows`` is the PR's ``(from_ts, to_ts)`` rows ordered by ``(from_ts, seq, id)``.
+    Mirrors the invariant in ``revisions._revisions_need_recontiguation`` (design
+    decisions 048 + 049): an empty set means the chain is contiguous and well-formed.
+
+    Categories:
+      - ``backward``: a window with ``to_ts <= from_ts`` (backwards or zero-width).
+      - ``gap``:      a non-final window ending before the next window starts.
+      - ``overlap``:  a non-final window ending after the next window starts.
+      - ``open_mid``: a non-final window left open-ended (``to_ts`` is null).
+    """
+    violations: set[str] = set()
+    last = len(windows) - 1
+    for i, (from_ts, to_ts) in enumerate(windows):
+        if to_ts is not None and to_ts <= from_ts:
+            violations.add("backward")
+        if i == last:
+            continue
+        next_from = windows[i + 1][0]
+        if to_ts is None:
+            violations.add("open_mid")
+        elif to_ts < next_from:
+            violations.add("gap")
+        elif to_ts > next_from:
+            violations.add("overlap")
+    return violations
+
+
+class Command(BaseCommand):
+    help = (
+        "Read-only audit of PRRevision window contiguity (design decision 049).\n"
+        "Counts PRs whose persisted revision windows have gaps, overlaps, backward, or\n"
+        "mid-chain open-ended windows. Makes no writes; use this to size a one-off backfill."
+    )
+
+    def add_arguments(self, parser) -> None:  # type: ignore[override]
+        parser.add_argument("--repo", default=None, help="Restrict to owner/name (default: all active repos)")
+        parser.add_argument("--sample", type=int, default=10, help="Sample violating PR numbers to print per repo (default 10)")
+
+    def _repos(self, repo_str: Optional[str]) -> list[Repository]:
+        if repo_str:
+            if "/" not in repo_str:
+                raise CommandError("--repo must be in 'owner/name' format")
+            owner, name = repo_str.split("/", 1)
+            repos = list(Repository.objects.filter(owner=owner, name=name))
+            if not repos:
+                raise CommandError(f"Repository not found: {repo_str}")
+            return repos
+        return list(Repository.objects.filter(is_active=True).order_by("owner", "name"))
+
+    def _audit_repo(self, repo: Repository) -> tuple[int, int, dict[str, int], list[tuple[int, list[str]]]]:
+        rows: Iterable[tuple[int, int, Optional[datetime], Optional[datetime]]] = (
+            PRRevision.objects.filter(pull_request__repository=repo)
+            .order_by("pull_request_id", "from_ts", "seq", "id")
+            .values_list("pull_request_id", "pull_request__number", "from_ts", "to_ts")
+            .iterator(chunk_size=2000)
+        )
+        total_prs = 0
+        viol_prs = 0
+        by_cat: dict[str, int] = {"gap": 0, "overlap": 0, "backward": 0, "open_mid": 0}
+        samples: list[tuple[int, list[str]]] = []
+        for _pid, group in itertools.groupby(rows, key=lambda r: r[0]):
+            grp = list(group)
+            total_prs += 1
+            windows = [(r[2], r[3]) for r in grp]
+            cats = classify_revision_windows(windows)
+            if not cats:
+                continue
+            viol_prs += 1
+            for cat in cats:
+                by_cat[cat] += 1
+            return_number = grp[0][1]
+            samples.append((int(return_number), sorted(cats)))
+        return total_prs, viol_prs, by_cat, samples
+
+    def handle(self, *args, **options):  # type: ignore[override]
+        repo_str: Optional[str] = options.get("repo")
+        sample: int = int(options["sample"])
+        repos = self._repos(repo_str)
+
+        grand_total = 0
+        grand_viol = 0
+        grand_by_cat: dict[str, int] = {"gap": 0, "overlap": 0, "backward": 0, "open_mid": 0}
+
+        self.stdout.write(self.style.MIGRATE_HEADING("PRRevision contiguity audit (read-only)"))
+        for repo in repos:
+            total_prs, viol_prs, by_cat, samples = self._audit_repo(repo)
+            grand_total += total_prs
+            grand_viol += viol_prs
+            for cat, n in by_cat.items():
+                grand_by_cat[cat] += n
+            cat_str = ", ".join(f"{cat}={by_cat[cat]}" for cat in ("gap", "overlap", "backward", "open_mid"))
+            self.stdout.write(f" - {repo.owner}/{repo.name}: {viol_prs}/{total_prs} PRs violate contiguity ({cat_str})")
+            for number, cats in samples[:sample]:
+                self.stdout.write(f"     PR #{number}: {', '.join(cats)}")
+            if viol_prs > sample:
+                self.stdout.write(f"     … and {viol_prs - min(sample, len(samples))} more")
+
+        grand_cat_str = ", ".join(f"{cat}={grand_by_cat[cat]}" for cat in ("gap", "overlap", "backward", "open_mid"))
+        style = self.style.WARNING if grand_viol else self.style.SUCCESS
+        self.stdout.write(style(f"Total: {grand_viol}/{grand_total} PRs violate contiguity ({grand_cat_str})"))

--- a/qb_site/analyzer/management/commands/audit_revision_contiguity.py
+++ b/qb_site/analyzer/management/commands/audit_revision_contiguity.py
@@ -40,16 +40,38 @@ def classify_revision_windows(windows: list[tuple[Optional[datetime], Optional[d
     return violations
 
 
+_CATS = ("gap", "overlap", "backward", "open_mid")
+
+
 class Command(BaseCommand):
     help = (
-        "Read-only audit of PRRevision window contiguity (design decision 049).\n"
-        "Counts PRs whose persisted revision windows have gaps, overlaps, backward, or\n"
-        "mid-chain open-ended windows. Makes no writes; use this to size a one-off backfill."
+        "Audit (and optionally heal) PRRevision window contiguity (design decision 049).\n"
+        "Without --fix this is read-only: it counts PRs whose persisted revision windows\n"
+        "have gaps, overlaps, backward, or mid-chain open-ended windows. With --fix it\n"
+        "rebuilds each violating PR (revisions, then queue windows) to restore contiguity."
     )
 
     def add_arguments(self, parser) -> None:  # type: ignore[override]
         parser.add_argument("--repo", default=None, help="Restrict to owner/name (default: all active repos)")
         parser.add_argument("--sample", type=int, default=10, help="Sample violating PR numbers to print per repo (default 10)")
+        parser.add_argument(
+            "--fix",
+            action="store_true",
+            default=False,
+            help="Rebuild violating PRs to heal them (mutating). Default: read-only audit.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="With --fix, max violating PRs to heal per repo (0 = all).",
+        )
+        parser.add_argument(
+            "--skip-windows",
+            action="store_true",
+            default=False,
+            help="With --fix, only rebuild revisions; skip the queue-window rebuild.",
+        )
 
     def _repos(self, repo_str: Optional[str]) -> list[Repository]:
         if repo_str:
@@ -62,7 +84,11 @@ class Command(BaseCommand):
             return repos
         return list(Repository.objects.filter(is_active=True).order_by("owner", "name"))
 
-    def _audit_repo(self, repo: Repository) -> tuple[int, int, dict[str, int], list[tuple[int, list[str]]]]:
+    def _audit_repo(self, repo: Repository) -> tuple[int, dict[str, int], list[tuple[int, int, list[str]]]]:
+        """Return ``(total_prs, by_category_counts, violators)``.
+
+        ``violators`` is a list of ``(pull_request_id, number, sorted_categories)``.
+        """
         rows: Iterable[tuple[int, int, Optional[datetime], Optional[datetime]]] = (
             PRRevision.objects.filter(pull_request__repository=repo)
             .order_by("pull_request_id", "from_ts", "seq", "id")
@@ -70,46 +96,104 @@ class Command(BaseCommand):
             .iterator(chunk_size=2000)
         )
         total_prs = 0
-        viol_prs = 0
-        by_cat: dict[str, int] = {"gap": 0, "overlap": 0, "backward": 0, "open_mid": 0}
-        samples: list[tuple[int, list[str]]] = []
-        for _pid, group in itertools.groupby(rows, key=lambda r: r[0]):
+        by_cat: dict[str, int] = {cat: 0 for cat in _CATS}
+        violators: list[tuple[int, int, list[str]]] = []
+        for pid, group in itertools.groupby(rows, key=lambda r: r[0]):
             grp = list(group)
             total_prs += 1
-            windows = [(r[2], r[3]) for r in grp]
-            cats = classify_revision_windows(windows)
+            cats = classify_revision_windows([(r[2], r[3]) for r in grp])
             if not cats:
                 continue
-            viol_prs += 1
             for cat in cats:
                 by_cat[cat] += 1
-            return_number = grp[0][1]
-            samples.append((int(return_number), sorted(cats)))
-        return total_prs, viol_prs, by_cat, samples
+            violators.append((int(pid), int(grp[0][1]), sorted(cats)))
+        return total_prs, by_cat, violators
+
+    def _fix_repo(
+        self, repo: Repository, violators: list[tuple[int, int, list[str]]], *, limit: int, rebuild_windows: bool
+    ) -> tuple[int, int, int]:
+        """Rebuild violating PRs. Returns ``(fixed, noop, failed)`` counts."""
+        from django.utils import timezone
+
+        from analyzer.models import PRRevisionBuildState, QueueRuleSet
+        from analyzer.services.queue_window_build_state import record_queue_window_build_states
+        from analyzer.services.queue_windows import rebuild_queue_windows_for_pr
+        from analyzer.services.revisions import rebuild_pr_revisions
+        from syncer.models import PullRequest
+
+        rule_sets = list(QueueRuleSet.objects.filter(repository=repo, is_active=True))
+        targets = [v[0] for v in violators]
+        if limit:
+            targets = targets[:limit]
+
+        fixed = noop = failed = 0
+        for pr_id in targets:
+            try:
+                pr = PullRequest.objects.get(id=pr_id)
+                # The deployed self-heal makes rebuild_pr_revisions detect the contiguity
+                # violation and run a full rebuild past the noop short-circuit.
+                res = rebuild_pr_revisions(pr)
+                if res.strategy == "noop":
+                    noop += 1
+                    self.stderr.write(f"     PR #{pr.number}: rebuild was a noop (not healed)")
+                    continue
+                if rebuild_windows and rule_sets:
+                    summary = rebuild_queue_windows_for_pr(pr=pr, rule_sets=rule_sets)
+                    state, _ = PRRevisionBuildState.objects.get_or_create(pull_request=pr)
+                    record_queue_window_build_states(
+                        pr=pr,
+                        rule_sets=rule_sets,
+                        per_ruleset=summary.get("per_ruleset", {}),
+                        revision_version=int(state.revision_version),
+                        built_at=timezone.now(),
+                    )
+                fixed += 1
+                if fixed % 100 == 0:
+                    self.stdout.write(f"     … healed {fixed}/{len(targets)}")
+            except Exception as exc:  # pragma: no cover - best-effort per-PR recovery
+                failed += 1
+                self.stderr.write(f"     PR id={pr_id}: fix failed: {exc}")
+        return fixed, noop, failed
 
     def handle(self, *args, **options):  # type: ignore[override]
         repo_str: Optional[str] = options.get("repo")
         sample: int = int(options["sample"])
+        do_fix: bool = bool(options["fix"])
+        limit: int = int(options["limit"])
+        rebuild_windows: bool = not bool(options["skip_windows"])
         repos = self._repos(repo_str)
 
         grand_total = 0
         grand_viol = 0
-        grand_by_cat: dict[str, int] = {"gap": 0, "overlap": 0, "backward": 0, "open_mid": 0}
+        grand_by_cat: dict[str, int] = {cat: 0 for cat in _CATS}
+        grand_fixed = grand_noop = grand_failed = 0
 
-        self.stdout.write(self.style.MIGRATE_HEADING("PRRevision contiguity audit (read-only)"))
+        heading = "PRRevision contiguity audit" + (" + heal (--fix)" if do_fix else " (read-only)")
+        self.stdout.write(self.style.MIGRATE_HEADING(heading))
         for repo in repos:
-            total_prs, viol_prs, by_cat, samples = self._audit_repo(repo)
+            total_prs, by_cat, violators = self._audit_repo(repo)
+            viol_prs = len(violators)
             grand_total += total_prs
             grand_viol += viol_prs
-            for cat, n in by_cat.items():
-                grand_by_cat[cat] += n
-            cat_str = ", ".join(f"{cat}={by_cat[cat]}" for cat in ("gap", "overlap", "backward", "open_mid"))
+            for cat in _CATS:
+                grand_by_cat[cat] += by_cat[cat]
+            cat_str = ", ".join(f"{cat}={by_cat[cat]}" for cat in _CATS)
             self.stdout.write(f" - {repo.owner}/{repo.name}: {viol_prs}/{total_prs} PRs violate contiguity ({cat_str})")
-            for number, cats in samples[:sample]:
+            for _pid, number, cats in violators[:sample]:
                 self.stdout.write(f"     PR #{number}: {', '.join(cats)}")
             if viol_prs > sample:
-                self.stdout.write(f"     … and {viol_prs - min(sample, len(samples))} more")
+                self.stdout.write(f"     … and {viol_prs - sample} more")
 
-        grand_cat_str = ", ".join(f"{cat}={grand_by_cat[cat]}" for cat in ("gap", "overlap", "backward", "open_mid"))
+            if do_fix and violators:
+                fixed, noop, failed = self._fix_repo(repo, violators, limit=limit, rebuild_windows=rebuild_windows)
+                grand_fixed += fixed
+                grand_noop += noop
+                grand_failed += failed
+                self.stdout.write(self.style.SUCCESS(f"   healed {fixed}, noop {noop}, failed {failed}"))
+
+        grand_cat_str = ", ".join(f"{cat}={grand_by_cat[cat]}" for cat in _CATS)
         style = self.style.WARNING if grand_viol else self.style.SUCCESS
         self.stdout.write(style(f"Total: {grand_viol}/{grand_total} PRs violate contiguity ({grand_cat_str})"))
+        if do_fix:
+            self.stdout.write(self.style.SUCCESS(f"Healed {grand_fixed}, noop {grand_noop}, failed {grand_failed}"))
+            self.stdout.write("Re-run without --fix to confirm violations dropped to 0.")

--- a/qb_site/analyzer/services/revisions.py
+++ b/qb_site/analyzer/services/revisions.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import F, Max
+from django.db.models import Max
 from django.utils import timezone
 
 from syncer.models import (
@@ -454,6 +454,32 @@ def _normalize_windows(
     return stitched
 
 
+def _revisions_need_recontiguation(pr: PullRequest) -> bool:
+    """Return True if a PR's persisted revision windows violate contiguity.
+
+    Invariant (design decisions 048 + 049): rows ordered by ``from_ts`` must satisfy
+    ``to_ts[i] == from_ts[i+1]`` for every adjacent pair, every non-final window must
+    be closed and forward (``from_ts < to_ts``), and only the final window may be
+    open-ended. Any violation — a malformed window (``to_ts <= from_ts``), a gap or
+    overlap between neighbours (``to_ts[i] != from_ts[i+1]``), or a non-final window
+    with a null ``to_ts`` — means the rows escape the append delete sweep and re-noop
+    forever, so we force a healing full rebuild. A no-op on `_normalize_windows`
+    output, which already guarantees the invariant.
+    """
+    rows = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts", "seq", "id").values_list("from_ts", "to_ts"))
+    last = len(rows) - 1
+    for i, (from_ts, to_ts) in enumerate(rows):
+        if i == last:
+            # Final window may be open-ended, but if closed it must be forward.
+            if to_ts is not None and to_ts <= from_ts:
+                return True
+            continue
+        # Non-final window must be closed, forward, and meet the next window's start.
+        if to_ts is None or to_ts <= from_ts or to_ts != rows[i + 1][0]:
+            return True
+    return False
+
+
 @transaction.atomic
 def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] = None) -> RebuildResult:
     """Rebuild head revision windows for a PR from timeline events and CI.
@@ -494,11 +520,18 @@ def rebuild_pr_revisions(pr: PullRequest, latest_signal_ts: Optional[datetime] =
         needs_full = True
     if dirty_was_set:
         needs_full = True
-    # Self-healing cleanup (design decision 048): a malformed window (to_ts <
-    # from_ts) holding max(from_ts) escapes the append delete sweep and re-noops on
-    # every rebuild. Force a full rebuild so the corrected builder output replaces
-    # it. Converges: once cleaned, no malformed row remains and this is a no-op.
-    if not needs_full and PRRevision.objects.filter(pull_request=pr, to_ts__isnull=False, to_ts__lt=F("from_ts")).exists():
+    # Self-healing cleanup (design decisions 048 + 049): legacy rows that violate
+    # the contiguity invariant escape the append delete sweep and re-noop on every
+    # rebuild. Force a full rebuild so `_normalize_windows` re-stitches them.
+    # Converges: once stitched, the invariant holds and this is a no-op.
+    #
+    # Doc 048's original self-heal only caught a single malformed window
+    # (`to_ts < from_ts`). Doc 049 extends it to *gaps and overlaps* between
+    # adjacent windows (`to_ts[i] != from_ts[i+1]`): a head dropped by a pre-048
+    # builder leaves individually-valid rows with a hole between them, which pins
+    # the analyzer to a "missing head" inside the gap and makes the queue-window
+    # builder emit FK-less CI attribution that loops forever in the staleness sweep.
+    if not needs_full and _revisions_need_recontiguation(pr):
         needs_full = True
 
     has_existing = PRRevision.objects.filter(pull_request=pr).exists()

--- a/qb_site/analyzer/tasks/collect_convergence.py
+++ b/qb_site/analyzer/tasks/collect_convergence.py
@@ -46,7 +46,11 @@ def collect_analyzer_convergence_task() -> dict:
                 rule_set_id__in=rule_set_ids,
             ).values("pull_request_id", "rule_set_id", "revision_version_built", "windows_built_at")
             rs_state_map = {(int(row["pull_request_id"]), int(row["rule_set_id"])): row for row in rs_state_rows}
-            _ci_attribution_types = [QueueWindowEventType.CI_PASSED, QueueWindowEventType.CI_FAILED]
+            # Keep these stale conditions in sync with the sweep's prefilter
+            # (rebuild_queue_windows_sweep.py): missing rollup fields and pre-migration
+            # null event_type.  A CI event_type with both CI FKs null is intentionally
+            # excluded — it is a legitimate terminal state, not a defect, and flagging it
+            # produced a permanent stale loop (doc 049).
             rollup_stale_pairs = set(
                 (
                     int(row["pull_request_id"]),
@@ -56,21 +60,7 @@ def collect_analyzer_convergence_task() -> dict:
                     pull_request_id__in=pr_ids,
                     rule_set_id__in=rule_set_ids,
                 )
-                .filter(
-                    Q(window_count=0)
-                    | Q(first_on_queue_ts__isnull=True)
-                    | Q(opened_by_event_type__isnull=True)
-                    | Q(
-                        opened_by_event_type__in=_ci_attribution_types,
-                        opened_by_check_run__isnull=True,
-                        opened_by_status_context__isnull=True,
-                    )
-                    | Q(
-                        closed_by_event_type__in=_ci_attribution_types,
-                        closed_by_check_run__isnull=True,
-                        closed_by_status_context__isnull=True,
-                    )
-                )
+                .filter(Q(window_count=0) | Q(first_on_queue_ts__isnull=True) | Q(opened_by_event_type__isnull=True))
                 .values("pull_request_id", "rule_set_id")
                 .distinct()
             )

--- a/qb_site/analyzer/tasks/rebuild_queue_windows_sweep.py
+++ b/qb_site/analyzer/tasks/rebuild_queue_windows_sweep.py
@@ -7,14 +7,10 @@ from django.utils import timezone
 from django.db.models import Count, Exists, F, Min, OuterRef, Q
 
 from analyzer.models import PRQueueWindow, PRQueueWindowBuildState, PRRevision, PRRevisionBuildState, QueueRuleSet
-from analyzer.models.queue_window import QueueWindowEventType
 from analyzer.services.queue_window_build_state import record_queue_window_build_states
 from analyzer.services.queue_windows import rebuild_queue_windows_for_pr
 from core.models import Repository
 from syncer.models import PullRequest
-
-
-_CI_ATTRIBUTION_TYPES = [QueueWindowEventType.CI_PASSED, QueueWindowEventType.CI_FAILED]
 
 
 def _is_ruleset_stale_for_pr(
@@ -48,15 +44,24 @@ def _is_ruleset_stale_for_pr(
     - Label/state change (``gh_updated_at``) → ``min_ruleset_state_windows_built_at < gh_updated_at``
     - CI write since last build (``latest_ci_synced_at``) → ``min_ruleset_state_windows_built_at < revision_build_state__latest_ci_synced_at``
     - Rollup fields missing           → ``has_rollup_backfill=True`` (Exists subquery)
-    - Attribution fields missing/inconsistent → ``has_attribution_backfill=True`` (Exists subquery)
-      Covers: pre-migration windows (opened_by_event_type IS NULL) and post-expire-task
-      partial failures (CI event_type with both CI FKs null).
+    - Attribution event_type missing  → ``has_attribution_backfill=True`` (Exists subquery)
+      Covers pre-migration windows (``opened_by_event_type IS NULL``); a rebuild repairs
+      them by recomputing attribution from scratch.
+
+      NOTE (doc 049): a CI ``event_type`` (CI_PASSED/CI_FAILED) with both CI FKs null is
+      deliberately *not* treated as stale. The window builder legitimately produces
+      FK-less CI attribution whenever a CI-eligibility flip cannot be tied to a surviving
+      ``CommitCheckRun``/``CommitStatusContext`` row (CI rows expired by
+      ``syncer.expire_stale_ci_for_repo``, or an unresolved head at the boundary). A
+      rebuild reproduces the identical FK-less attribution, so flagging it produced a
+      permanent stale loop. The underlying revision-gap cause is fixed separately by the
+      revision contiguity self-heal (doc 049).
     """
     # Existing windows have missing rollup fields (window_count=0 or first_on_queue_ts=None).
     if has_rollup_backfill:
         return True
 
-    # Existing windows have missing or inconsistent attribution fields.
+    # Existing windows are pre-migration (event_type not yet populated).
     if has_attribution_backfill:
         return True
 
@@ -118,23 +123,14 @@ def rebuild_queue_windows_sweep_task(
             pull_request=OuterRef("pk"),
             rule_set_id__in=rule_set_ids,
         ).filter(Q(window_count=0) | Q(first_on_queue_ts__isnull=True))
+        # Pre-migration windows whose event_type was never populated; a rebuild repairs
+        # them.  A CI event_type with both CI FKs null is intentionally excluded — that
+        # is a legitimate terminal state, not a defect (see _is_ruleset_stale_for_pr and
+        # doc 049).
         attribution_backfill = PRQueueWindow.objects.filter(
             pull_request=OuterRef("pk"),
             rule_set_id__in=rule_set_ids,
-        ).filter(
-            # Pre-migration: event_type not yet populated.
-            Q(opened_by_event_type__isnull=True)
-            # Post-expire-task partial failure: CI event type but both CI FKs null.
-            | Q(
-                opened_by_event_type__in=_CI_ATTRIBUTION_TYPES,
-                opened_by_check_run__isnull=True,
-                opened_by_status_context__isnull=True,
-            )
-            | Q(
-                closed_by_event_type__in=_CI_ATTRIBUTION_TYPES,
-                closed_by_check_run__isnull=True,
-                closed_by_status_context__isnull=True,
-            )
+            opened_by_event_type__isnull=True,
         )
 
         pr_qs = PullRequest.objects.filter(repository=repo, timeline_backfill_done=True)
@@ -285,25 +281,14 @@ def rebuild_queue_windows_sweep_task(
                 .filter(Q(window_count=0) | Q(first_on_queue_ts__isnull=True))
                 .values_list("pull_request_id", "rule_set_id")
             )
+            # Mirror the prefilter's attribution_backfill subquery: only pre-migration
+            # null event_type counts (doc 049 — FK-less CI attribution is not a defect).
             attribution_backfill_pairs = set(
                 PRQueueWindow.objects.filter(
                     pull_request_id__in=pr_ids,
                     rule_set_id__in=rule_set_ids,
-                )
-                .filter(
-                    Q(opened_by_event_type__isnull=True)
-                    | Q(
-                        opened_by_event_type__in=_CI_ATTRIBUTION_TYPES,
-                        opened_by_check_run__isnull=True,
-                        opened_by_status_context__isnull=True,
-                    )
-                    | Q(
-                        closed_by_event_type__in=_CI_ATTRIBUTION_TYPES,
-                        closed_by_check_run__isnull=True,
-                        closed_by_status_context__isnull=True,
-                    )
-                )
-                .values_list("pull_request_id", "rule_set_id")
+                    opened_by_event_type__isnull=True,
+                ).values_list("pull_request_id", "rule_set_id")
             )
 
             for pr in pr_batch:

--- a/qb_site/analyzer/tests/management/test_audit_revision_contiguity.py
+++ b/qb_site/analyzer/tests/management/test_audit_revision_contiguity.py
@@ -1,0 +1,108 @@
+"""Tests for the read-only `audit_revision_contiguity` command (design decision 049)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+
+from analyzer.management.commands.audit_revision_contiguity import classify_revision_windows
+from analyzer.models import PRRevision
+from core.models import Repository
+from syncer.models import PullRequest
+
+
+class TestClassifyRevisionWindows(SimpleTestCase):
+    """Pure-logic coverage (no database)."""
+
+    def _w(self, *pairs):
+        # pairs are (from_min, to_min|None) integer minutes for readability
+        base = timezone.now()
+        return [(base + timedelta(minutes=f), None if t is None else base + timedelta(minutes=t)) for f, t in pairs]
+
+    def test_empty_is_clean(self) -> None:
+        self.assertEqual(classify_revision_windows([]), set())
+
+    def test_single_open_is_clean(self) -> None:
+        self.assertEqual(classify_revision_windows(self._w((0, None))), set())
+
+    def test_contiguous_is_clean(self) -> None:
+        self.assertEqual(classify_revision_windows(self._w((0, 30), (30, None))), set())
+
+    def test_gap(self) -> None:
+        self.assertEqual(classify_revision_windows(self._w((0, 30), (60, None))), {"gap"})
+
+    def test_overlap(self) -> None:
+        self.assertEqual(classify_revision_windows(self._w((0, 90), (60, None))), {"overlap"})
+
+    def test_backward(self) -> None:
+        # A lone backward window (to_ts < from_ts) with no neighbour to also gap against.
+        self.assertEqual(classify_revision_windows(self._w((30, 10))), {"backward"})
+
+    def test_open_mid(self) -> None:
+        self.assertEqual(classify_revision_windows(self._w((0, None), (30, None))), {"open_mid"})
+
+    def test_multiple_categories(self) -> None:
+        # gap between 0->30 and 60, then a backward final window.
+        self.assertEqual(classify_revision_windows(self._w((0, 30), (60, 50))), {"gap", "backward"})
+
+
+class TestAuditRevisionContiguityCommand(TestCase):
+    def setUp(self) -> None:
+        self.repo = Repository.objects.create(owner="o", name="r", default_branch="master", is_active=True)
+        self.t0 = timezone.now() - timedelta(days=1)
+
+    def _at(self, minutes: int):
+        return self.t0 + timedelta(minutes=minutes)
+
+    def _pr(self, number: int) -> PullRequest:
+        return PullRequest.objects.create(
+            repository=self.repo,
+            number=number,
+            author=None,
+            state="open",
+            is_draft=False,
+            gh_created_at=self._at(0),
+            gh_updated_at=self._at(0),
+            base_ref_name="master",
+            head_ref_name="b",
+            head_repo_owner_login="o",
+            head_repo_name="fork",
+            title="t",
+            body="",
+            additions=0,
+            deletions=0,
+            changed_files_count=0,
+            timeline_backfill_done=True,
+        )
+
+    def _rev(self, pr, head, from_min, to_min, seq):
+        PRRevision.objects.create(
+            pull_request=pr,
+            head_sha=head,
+            from_ts=self._at(from_min),
+            to_ts=None if to_min is None else self._at(to_min),
+            seq=seq,
+        )
+
+    def test_reports_gap_and_clean_prs(self) -> None:
+        # Contiguous PR — must not be reported.
+        clean = self._pr(1)
+        self._rev(clean, "a", 0, 30, 0)
+        self._rev(clean, "b", 30, None, 1)
+        # Gappy PR — must be reported.
+        gappy = self._pr(2)
+        self._rev(gappy, "a", 0, 30, 0)
+        self._rev(gappy, "b", 60, None, 1)
+
+        out = StringIO()
+        call_command("audit_revision_contiguity", "--repo", "o/r", stdout=out)
+        text = out.getvalue()
+
+        self.assertIn("1/2 PRs violate contiguity", text)
+        self.assertIn("gap=1", text)
+        self.assertIn("PR #2", text)
+        self.assertNotIn("PR #1", text)

--- a/qb_site/analyzer/tests/management/test_audit_revision_contiguity.py
+++ b/qb_site/analyzer/tests/management/test_audit_revision_contiguity.py
@@ -106,3 +106,45 @@ class TestAuditRevisionContiguityCommand(TestCase):
         self.assertIn("gap=1", text)
         self.assertIn("PR #2", text)
         self.assertNotIn("PR #1", text)
+
+    def test_fix_heals_gappy_pr(self) -> None:
+        from analyzer.models import PRRevisionBuildState, QueueRuleSet
+        from analyzer.services.revisions import PR_REVISION_BUILDER_VERSION
+        from syncer.models import CommitCheckRun
+
+        QueueRuleSet.objects.create(
+            repository=self.repo, version=1, require_open=True, require_not_draft=True, require_ci_success=False
+        )
+        pr = self._pr(5)
+        pr.head_sha = "hLate"
+        pr.save(update_fields=["head_sha"])
+        # Gappy revisions: hEarly ends at +30, hLate starts at +60.
+        self._rev(pr, "hEarly", 0, 30, 0)
+        self._rev(pr, "hLate", 60, None, 1)
+        for head, c in (("hEarly", 5), ("hLate", 65)):
+            CommitCheckRun.objects.create(
+                repository=self.repo,
+                github_node_id=f"cr_{head}",
+                head_sha=head,
+                name="ci",
+                status="COMPLETED",
+                conclusion="SUCCESS",
+                gh_started_at=self._at(c - 5),
+                gh_completed_at=self._at(c),
+            )
+        # Clean build state so a revision rebuild would otherwise noop.
+        PRRevisionBuildState.objects.create(
+            pull_request=pr,
+            revision_version=1,
+            builder_version=PR_REVISION_BUILDER_VERSION,
+            built_through_ts=self._at(70),
+            dirty_from_ts=None,
+        )
+
+        out, err = StringIO(), StringIO()
+        call_command("audit_revision_contiguity", "--repo", "o/r", "--fix", stdout=out, stderr=err)
+
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts", "seq", "id"))
+        for a, b in zip(revs, revs[1:]):
+            self.assertEqual(a.to_ts, b.from_ts, "revisions must be contiguous after --fix")
+        self.assertIn("healed 1", out.getvalue())

--- a/qb_site/analyzer/tests/tasks/test_rebuild_queue_windows_sweep_attribution.py
+++ b/qb_site/analyzer/tests/tasks/test_rebuild_queue_windows_sweep_attribution.py
@@ -1,8 +1,9 @@
-"""Tests for W4b: sweep staleness extension for attribution backfill.
+"""Tests for sweep staleness handling of queue-window attribution.
 
-Verifies that the rebuild_queue_windows_sweep_task detects and rebuilds:
-- Pre-migration windows with null opened_by_event_type.
-- Windows with CI event_type but both CI FKs null (post-expire-task partial failure).
+Verifies that the rebuild_queue_windows_sweep_task:
+- Detects and rebuilds pre-migration windows with null opened_by_event_type.
+- Does NOT flag windows whose CI event_type carries null CI FKs — that is a
+  legitimate terminal state, not a defect, and flagging it looped forever (doc 049).
 """
 
 from __future__ import annotations
@@ -100,11 +101,17 @@ class TestSweepAttributionBackfill(_Base):
         # After rebuild, INITIAL_STATE should be populated.
         self.assertEqual(win.opened_by_event_type, QueueWindowEventType.INITIAL_STATE)
 
-    def test_ci_event_type_with_null_fks_triggers_rebuild(self) -> None:
-        """Window with CI_PASSED event_type but both CI FKs null is detected and rebuilt."""
+    def test_ci_event_type_with_null_fks_is_not_stale(self) -> None:
+        """opened_by CI_PASSED with both CI FKs null is an accepted terminal state
+        (doc 049): the sweep must neither flag nor rebuild it."""
         pr = self._mk_pr(2)
-        self._seed_up_to_date_build_state(pr)
-        # Simulate post-expire-task partial failure: FK was nulled, event_type still set.
+        state = self._seed_up_to_date_build_state(pr)
+        # Make every non-attribution staleness signal up to date so attribution is the
+        # only thing that could flag this PR.
+        QueueRuleSet.objects.filter(pk=self.rule_set.pk).update(updated_at=state.windows_built_at - timezone.timedelta(minutes=1))
+        # FK-less CI attribution: produced legitimately when a CI-eligibility flip
+        # cannot be tied to a surviving CI row.  A rebuild reproduces it identically,
+        # so flagging it would loop forever.
         PRQueueWindow.objects.create(
             pull_request=pr,
             rule_set=self.rule_set,
@@ -120,11 +127,10 @@ class TestSweepAttributionBackfill(_Base):
 
         res = rebuild_queue_windows_sweep_task.apply(kwargs={"max_prs_per_repo": 5}).get()
 
-        # Rebuild fires; since no CI rows exist for this label-only ruleset, the window
-        # is rebuilt from scratch with INITIAL_STATE.
-        self.assertEqual(res["windows_rebuilt"], 1)
+        self.assertEqual(res["windows_rebuilt"], 0)
+        self.assertEqual(res["prs_stale_ruleset"], 0)
         win = PRQueueWindow.objects.get(pull_request=pr, rule_set=self.rule_set)
-        self.assertNotEqual(win.opened_by_event_type, QueueWindowEventType.CI_PASSED)
+        self.assertEqual(win.opened_by_event_type, QueueWindowEventType.CI_PASSED)
 
     def test_window_with_correct_attribution_not_spuriously_rebuilt(self) -> None:
         """Window with proper INITIAL_STATE attribution is not detected as stale."""
@@ -145,10 +151,11 @@ class TestSweepAttributionBackfill(_Base):
 
         self.assertEqual(res["windows_rebuilt"], 0)
 
-    def test_closed_by_ci_event_type_with_null_fks_triggers_rebuild(self) -> None:
-        """Window with CI_FAILED closed_by_event_type but both closed CI FKs null is detected."""
+    def test_closed_by_ci_event_type_with_null_fks_is_not_stale(self) -> None:
+        """closed_by CI_FAILED with both closed CI FKs null is likewise accepted (doc 049)."""
         pr = self._mk_pr(4)
-        self._seed_up_to_date_build_state(pr)
+        state = self._seed_up_to_date_build_state(pr)
+        QueueRuleSet.objects.filter(pk=self.rule_set.pk).update(updated_at=state.windows_built_at - timezone.timedelta(minutes=1))
         PRQueueWindow.objects.create(
             pull_request=pr,
             rule_set=self.rule_set,
@@ -165,4 +172,5 @@ class TestSweepAttributionBackfill(_Base):
 
         res = rebuild_queue_windows_sweep_task.apply(kwargs={"max_prs_per_repo": 5}).get()
 
-        self.assertEqual(res["windows_rebuilt"], 1)
+        self.assertEqual(res["windows_rebuilt"], 0)
+        self.assertEqual(res["prs_stale_ruleset"], 0)

--- a/qb_site/analyzer/tests/test_pr_revisions_clamp.py
+++ b/qb_site/analyzer/tests/test_pr_revisions_clamp.py
@@ -21,6 +21,7 @@ from analyzer.services.revisions import (
     _build_ci_head_windows,
     _build_force_push_head_windows,
     _normalize_windows,
+    _revisions_need_recontiguation,
     rebuild_pr_revisions,
 )
 
@@ -337,6 +338,47 @@ class TestRebuildIntegration(ClampTestBase):
         self.assertEqual(revs[0].from_ts, self._at(0))
         self.assertEqual(revs[-1].to_ts, None)
 
+    def test_self_heals_gap_between_windows(self) -> None:
+        # Doc 049: a GAP between adjacent windows (to_ts[i] < from_ts[i+1]) where each
+        # row is individually valid. The 048 malformed self-heal (to_ts < from_ts only)
+        # misses it, so it would noop forever. The contiguity self-heal must rebuild.
+        pr = self._mk_pr(40, created_min=0, head_sha="hC")
+        # seq0 ends at 30 but seq1 starts at 60 -> a 30-minute coverage hole.
+        PRRevision.objects.create(pull_request=pr, head_sha="h0", from_ts=self._at(0), to_ts=self._at(30), seq=0)
+        PRRevision.objects.create(pull_request=pr, head_sha="hC", from_ts=self._at(60), to_ts=None, seq=1)
+        self._ci("h0", start_min=5)
+        self._ci("hC", start_min=60)
+        self._seed_state(pr, built_through_min=65)
+
+        self.assertTrue(_revisions_need_recontiguation(pr), "gap must be detected")
+
+        res = rebuild_pr_revisions(pr)
+        self.assertNotEqual(res.strategy, "noop", "gap must force a full rebuild, not noop")
+        self.assert_db_windows_valid(pr)
+        self.assertFalse(_revisions_need_recontiguation(pr), "gap must be healed")
+
+        # Converges: a second rebuild is a clean noop.
+        res2 = rebuild_pr_revisions(pr)
+        self.assertEqual(res2.strategy, "noop")
+        self.assert_db_windows_valid(pr)
+
+    def test_self_heals_overlap_between_windows(self) -> None:
+        # Doc 049: an OVERLAP / out-of-order pair (to_ts[i] > from_ts[i+1]); each row is
+        # individually valid (to_ts > from_ts) so the malformed self-heal misses it.
+        pr = self._mk_pr(41, created_min=0, head_sha="hC")
+        PRRevision.objects.create(pull_request=pr, head_sha="h0", from_ts=self._at(0), to_ts=self._at(90), seq=0)
+        PRRevision.objects.create(pull_request=pr, head_sha="hC", from_ts=self._at(60), to_ts=None, seq=1)
+        self._ci("h0", start_min=5)
+        self._ci("hC", start_min=60)
+        self._seed_state(pr, built_through_min=95)
+
+        self.assertTrue(_revisions_need_recontiguation(pr), "overlap must be detected")
+
+        res = rebuild_pr_revisions(pr)
+        self.assertNotEqual(res.strategy, "noop", "overlap must force a full rebuild, not noop")
+        self.assert_db_windows_valid(pr)
+        self.assertFalse(_revisions_need_recontiguation(pr), "overlap must be healed")
+
     def test_ci_only_pre_creation_then_force_push(self) -> None:
         # Build CI-only (commits before creation) -> clamped; then a force push lands.
         pr = self._mk_pr(12, created_min=0, head_sha="h1")
@@ -442,3 +484,60 @@ class TestRebuildIntegration(ClampTestBase):
             res2 = rebuild_pr_revisions(pr)
             self.assertEqual(res2.strategy, "noop", f"pattern {pattern} should converge")
             self.assert_db_windows_valid(pr)
+
+
+class TestRevisionsNeedRecontiguation(ClampTestBase):
+    """Unit coverage for the contiguity violation detector (design decision 049)."""
+
+    def _rev(self, pr: PullRequest, head: str, from_min: int, to_min: int | None, seq: int) -> None:
+        PRRevision.objects.create(
+            pull_request=pr,
+            head_sha=head,
+            from_ts=self._at(from_min),
+            to_ts=None if to_min is None else self._at(to_min),
+            seq=seq,
+        )
+
+    def test_empty_is_clean(self) -> None:
+        pr = self._mk_pr(50)
+        self.assertFalse(_revisions_need_recontiguation(pr))
+
+    def test_single_open_window_is_clean(self) -> None:
+        pr = self._mk_pr(51, head_sha="a")
+        self._rev(pr, "a", 0, None, 0)
+        self.assertFalse(_revisions_need_recontiguation(pr))
+
+    def test_contiguous_chain_is_clean(self) -> None:
+        pr = self._mk_pr(52, head_sha="b")
+        self._rev(pr, "a", 0, 30, 0)
+        self._rev(pr, "b", 30, None, 1)
+        self.assertFalse(_revisions_need_recontiguation(pr))
+
+    def test_gap_is_detected(self) -> None:
+        pr = self._mk_pr(53, head_sha="b")
+        self._rev(pr, "a", 0, 30, 0)
+        self._rev(pr, "b", 60, None, 1)
+        self.assertTrue(_revisions_need_recontiguation(pr))
+
+    def test_overlap_is_detected(self) -> None:
+        pr = self._mk_pr(54, head_sha="b")
+        self._rev(pr, "a", 0, 90, 0)
+        self._rev(pr, "b", 60, None, 1)
+        self.assertTrue(_revisions_need_recontiguation(pr))
+
+    def test_backward_non_final_window_is_detected(self) -> None:
+        pr = self._mk_pr(55, head_sha="b")
+        self._rev(pr, "a", 30, 10, 0)  # to_ts < from_ts
+        self._rev(pr, "b", 40, None, 1)
+        self.assertTrue(_revisions_need_recontiguation(pr))
+
+    def test_non_final_open_window_is_detected(self) -> None:
+        pr = self._mk_pr(56, head_sha="b")
+        self._rev(pr, "a", 0, None, 0)  # non-final but open-ended
+        self._rev(pr, "b", 30, None, 1)
+        self.assertTrue(_revisions_need_recontiguation(pr))
+
+    def test_backward_final_window_is_detected(self) -> None:
+        pr = self._mk_pr(57, head_sha="a")
+        self._rev(pr, "a", 30, 10, 0)  # lone closed window, to_ts < from_ts
+        self.assertTrue(_revisions_need_recontiguation(pr))

--- a/qb_site/analyzer/tests/test_revision_gap_queue_window_attribution.py
+++ b/qb_site/analyzer/tests/test_revision_gap_queue_window_attribution.py
@@ -1,0 +1,124 @@
+"""End-to-end regression for design decision 049.
+
+A coverage gap between two ``PRRevision`` windows makes the queue-window builder see a
+"missing head" inside the gap, flip eligibility, and attribute the flip to CI with no FK
+(``CI_PASSED``/``CI_FAILED`` + null CI FKs) — the shape that looped forever in the
+staleness sweep. This test reproduces that shape from a gap, then verifies the revision
+contiguity self-heal + a window rebuild removes it.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.db.models import Q
+from django.test import TestCase
+from django.utils import timezone
+
+from analyzer.models import PRQueueWindow, PRRevision, PRRevisionBuildState, QueueRuleSet
+from analyzer.models.queue_window import QueueWindowEventType
+from analyzer.services.queue_windows import rebuild_queue_windows_for_pr
+from analyzer.services.revisions import PR_REVISION_BUILDER_VERSION, rebuild_pr_revisions
+from core.models import Repository
+from syncer.models import CommitCheckRun, PullRequest, PRTimelineEvent, PRTimelineEventType
+
+
+_CI = [QueueWindowEventType.CI_PASSED, QueueWindowEventType.CI_FAILED]
+
+
+class TestRevisionGapQueueWindowAttribution(TestCase):
+    def setUp(self) -> None:
+        self.repo = Repository.objects.create(owner="o", name="r", default_branch="master", is_active=True)
+        self.t0 = timezone.now() - timedelta(days=2)
+        self.rule_set = QueueRuleSet.objects.create(
+            repository=self.repo,
+            version=1,
+            require_open=True,
+            require_not_draft=True,
+            require_ci_success=True,
+            ci_gating_mode=QueueRuleSet.CIGatingMode.ALL_REQUIRED_SUCCESS,
+            required_ci_contexts=["ci"],
+        )
+
+    def _at(self, minutes: int):
+        return self.t0 + timedelta(minutes=minutes)
+
+    def _ci(self, head: str, completed_min: int) -> None:
+        CommitCheckRun.objects.create(
+            repository=self.repo,
+            github_node_id=f"CR_{head}_{completed_min}",
+            head_sha=head,
+            name="ci",
+            status="COMPLETED",
+            conclusion="SUCCESS",
+            gh_started_at=self._at(completed_min - 5),
+            gh_completed_at=self._at(completed_min),
+        )
+
+    def _null_fk_ci_windows(self, pr: PullRequest) -> list[PRQueueWindow]:
+        return list(
+            PRQueueWindow.objects.filter(pull_request=pr).filter(
+                Q(opened_by_event_type__in=_CI, opened_by_check_run__isnull=True, opened_by_status_context__isnull=True)
+                | Q(closed_by_event_type__in=_CI, closed_by_check_run__isnull=True, closed_by_status_context__isnull=True)
+            )
+        )
+
+    def test_revision_gap_produces_fkless_ci_window_then_heals(self) -> None:
+        pr = PullRequest.objects.create(
+            repository=self.repo,
+            number=100,
+            author=None,
+            state="open",
+            is_draft=False,
+            gh_created_at=self._at(0),
+            gh_updated_at=self._at(45),
+            base_ref_name="master",
+            head_ref_name="b",
+            head_repo_owner_login="o",
+            head_repo_name="fork",
+            title="t",
+            body="",
+            additions=0,
+            deletions=0,
+            changed_files_count=0,
+            timeline_backfill_done=True,
+            commits_backfill_done=True,
+            head_sha="hLate",
+        )
+        # Legacy gappy revisions: hEarly ends at +30 but hLate starts at +60 -> gap [30, 60).
+        PRRevision.objects.create(pull_request=pr, head_sha="hEarly", from_ts=self._at(0), to_ts=self._at(30), seq=0)
+        PRRevision.objects.create(pull_request=pr, head_sha="hLate", from_ts=self._at(60), to_ts=None, seq=1)
+        self._ci("hEarly", completed_min=5)
+        self._ci("hLate", completed_min=65)
+        # An irrelevant label change inside the gap creates a boundary with no CI row, so
+        # the eligibility flip there is attributed to CI with no FK (the bug shape).
+        PRTimelineEvent.objects.create(
+            pull_request=pr,
+            type=PRTimelineEventType.LABELED,
+            occurred_at=self._at(45),
+            label_name="t-irrelevant",
+        )
+        # Clean build state so a revision rebuild would otherwise noop — mirrors the
+        # production rows that stayed stuck behind the noop short-circuit.
+        PRRevisionBuildState.objects.create(
+            pull_request=pr,
+            revision_version=1,
+            builder_version=PR_REVISION_BUILDER_VERSION,
+            built_through_ts=self._at(70),
+            dirty_from_ts=None,
+        )
+
+        # 1. The gap yields exactly one FK-less CI window (the convergence-loop precondition).
+        rebuild_queue_windows_for_pr(pr=pr, rule_sets=[self.rule_set])
+        self.assertEqual(len(self._null_fk_ci_windows(pr)), 1)
+
+        # 2. The contiguity self-heal forces a full rebuild (not a noop) and re-stitches.
+        res = rebuild_pr_revisions(pr)
+        self.assertNotEqual(res.strategy, "noop")
+        revs = list(PRRevision.objects.filter(pull_request=pr).order_by("from_ts", "seq", "id"))
+        for a, b in zip(revs, revs[1:]):
+            self.assertEqual(a.to_ts, b.from_ts, "healed revisions must be contiguous")
+
+        # 3. Rebuilding the windows over healed revisions removes the FK-less CI attribution.
+        rebuild_queue_windows_for_pr(pr=pr, rule_sets=[self.rule_set])
+        self.assertEqual(self._null_fk_ci_windows(pr), [])


### PR DESCRIPTION
The analyzer's `windows_stale` convergence metric sat pinned at 3 on mathlib4 for several days, with the queue-window sweep reporting the same `prs_stale_ruleset` every run while rebuilding zero of them. The cause is two stacked defects:
- First, those PRs had legacy non-contiguous `PRRevision` windows (a head dropped by a pre-048 builder left a hole between adjacent windows). Inside the gap the queue-window builder can't resolve a head, computes `ci_state="missing"`, flips queue eligibility, and attributes the flip to CI with both CI FKs null.
- Second, the staleness check treated that FK-less CI attribution as a defect — but a rebuild reproduces it identically, so the window was flagged, "rebuilt" to the same bytes, and re-flagged forever.

This extends the design-048 revision self-heal to detect gaps/overlaps and mid-chain open-ended windows (`to_ts[i] != from_ts[i+1]`), not just single malformed rows, so a violating PR forces a full rebuild past the noop short-circuit and `_normalize_windows` re-stitches it (converging to a no-op). It also stops the sweep and convergence collector from treating a CI `event_type` with null CI FKs as stale; that is a legitimate terminal state (CI rows expired, or an unresolved head at the boundary) and is no longer a defect signal. Pre-migration null `event_type` is still flagged and repaired. The reasoning is captured in design decision 049.

The three production PRs (38269, 21594, 20584) were already recovered out of band by forcing a revision rebuild; no GitHub CI re-fetch was needed since the CI data was already present. A read-only `audit_revision_contiguity` management command was added to size the historical backlog: it found 2259 PRs (~5.6%) with contiguity violations, which the revisions sweep no longer visits because they're long-closed. The command grew a `--fix` mode (with `--limit` batching and `--skip-windows`) that rebuilds each violating PR's revisions and queue windows to clear them in one pass; the plan is to run it once after deploy and re-audit to confirm it drops to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
