### PR TITLE
feat: on-demand assignment suggestions

### DIFF
--- a/.docker-env.example
+++ b/.docker-env.example
@@ -1,0 +1,29 @@
+# Docker environment for running this repo's Compose checks from a SANDBOXED shell.
+# Not needed in a normal terminal — `bash scripts/repo_check_compose.sh` just works there.
+#
+# WHY THIS EXISTS: Docker Desktop's credential helper cannot start under a sandbox that blocks
+# writes to ~/Library/Containers, and it takes every image pull down with it — even though this
+# project pulls only public images and needs no credentials at all. Pointing DOCKER_CONFIG at a
+# config with no "credsStore" skips the helper entirely.
+#
+# Full explanation, verification and undo: docs/sandboxed_docker_setup.md
+#
+# Copy to `.docker-env` (gitignored, absolute paths are machine-specific):
+#
+#   mkdir -p .docker-nocreds
+#   printf '{"auths":{}}\n' > .docker-nocreds/config.json
+#   ln -sfn /Applications/Docker.app/Contents/Resources/cli-plugins .docker-nocreds/cli-plugins
+#   cat > .docker-env <<EOF
+#   DOCKER_CONFIG=$(pwd)/.docker-nocreds
+#   DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
+#   EOF
+#
+# Then pass `.docker-env` to the sandbox wrapper, or: set -a; . ./.docker-env; set +a
+
+# Credential-helper-free Docker config. Kept in the repo deliberately: a new directory under
+# $HOME is not readable from the sandbox, while the repo is both readable and writable.
+DOCKER_CONFIG=/absolute/path/to/queueboard-core/.docker-nocreds
+
+# Required: overriding DOCKER_CONFIG also moves where the CLI resolves *contexts*, so the
+# desktop-linux context is no longer found and the daemon socket must be named explicitly.
+DOCKER_HOST=unix:///Users/<you>/.docker/run/docker.sock

--- a/.env.example
+++ b/.env.example
@@ -311,6 +311,10 @@ ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED=0
 ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT=10
 ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT=5
 ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=5
+# MAX_SNAPSHOT_AGE_SECONDS: refuse to answer from a queue snapshot older than this (0 disables).
+# Guards the no-active-rule-set fallback, where a long-dead snapshot row could otherwise be served
+# as live. 86400 = 24h, far above the 5-minute snapshot cadence.
+ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS=86400
 # Acceptance window in days (a proposal expires this long after creation unless accepted);
 # the per-reviewer notification_settings override is clamped to >= 7.
 ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS=7

--- a/.env.example
+++ b/.env.example
@@ -299,6 +299,18 @@ ANALYZER_ASSIGNMENT_PROPOSALS_DRY_RUN=0
 # CONSOLE_UNASSIGN_ENABLED: the console assigned-PR roster becomes a form letting a reviewer remove
 # themselves from PRs (self-service only; it never unassigns anyone else). Off by default.
 ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED=0
+# On-demand assignment suggestions (design doc 053): a reviewer asks "what should I review?"
+# via the `suggest-prs` Zulip command or the console suggestions page. Staged rollout: enable
+# the read path (ENABLED, harmless — read-only) on both surfaces first, then the console claim
+# write (CONSOLE_CLAIM_ENABLED; Zulip claiming reuses `assign`, gated by
+# ZULIP_ASSIGNMENT_MUTATIONS_ENABLED as before). LIMIT is the service default / console count;
+# ZULIP_LIMIT the shorter in-channel reply (a console link carries the rest); MAX_LABELS caps
+# the per-request label override set (form and query string alike).
+ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED=0
+ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED=0
+ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT=10
+ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT=5
+ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=5
 # Acceptance window in days (a proposal expires this long after creation unless accepted);
 # the per-reviewer notification_settings override is clamped to >= 7.
 ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS=7

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ celerybeat-schedule*
 docs/graphql/github-schema.json
 zuliprc
 .zulip-policy.local.json
+# Sandboxed-Docker setup (machine-specific absolute paths); see docs/sandboxed_docker_setup.md
+.docker-env
+.docker-nocreds/
 .github-app-config.local.json
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,33 @@ Notes
 
 ## Testing Guidelines
 - Use `bash scripts/repo_check_compose.sh` as the primary end-to-end test/check entrypoint.
+- **Never read the exit status of a check script you piped into `head`/`tail`/`grep`.** A shell
+  pipeline reports the *last* command's status, so `bash scripts/repo_check_compose.sh | tail -60`
+  returns `tail`'s `0` and a failed run reads as green. This has already produced a confident wrong
+  diagnosis — that the script swallows failures. It does not (`set -euo pipefail`, plus an explicit
+  `exit 1` on migrate failure); the invocation was at fault. Run it unpiped, or use
+  `set -o pipefail` / `${PIPESTATUS[0]}`, and confirm the status before trusting the output. The
+  same trap applies to `docker compose run ... | tail`.
+- If a check "passes", confirm it actually ran. A build that dies before any test executes can
+  still print a plausible tail; scan for the step markers (`[1/12]` … `[12/12]`) or a test count,
+  not just the absence of a traceback.
 - Exercise dashboard generation with the provided fixtures via `uv run python -m queueboard.dashboard ...`; capture `before/` and `after/` HTML snapshots when comparing layout changes.
 - Keep unit tests colocated (`test_*.py`); expand `src/queueboard/test_state_evolution.py` or add pytest modules under the relevant Django app (`qb_site/<app>/tests/`).
 - If Compose/Postgres is unavailable, run focused non-DB tests where possible and clearly call out coverage gaps.
+- If `repo_check_compose.sh` itself cannot run but Docker can, reproduce its coverage step by step
+  rather than settling for "ran the tests" — steps 2 and 4–6 are cheap and catch things the suites
+  do not (an unmigrated model change, a table missing from the backup policy):
+
+  | step | command |
+  | --- | --- |
+  | 2 | `uv run python scripts/validate_github_graphql.py` (host; writes a gitignored schema) |
+  | 4 | `python scripts/validate_backup_policy.py` |
+  | 5 | `python qb_site/manage.py check` |
+  | 6 | `python qb_site/manage.py makemigrations --dry-run --check` |
+  | 7–12 | `env DJANGO_SETTINGS_MODULE=qb_site.settings.ci python qb_site/manage.py test <app>` for `core`, `syncer`, `analyzer`, `api`, `zulip_bot`, `console` |
+
+  Steps 4–12 run under `docker compose run --rm --no-deps -T web …` against cached images. Report
+  which steps ran, by number.
 - Document any manual data validation or backfill steps in your PR description so reviewers can reproduce the checks.
 
 ## Commit & Pull Request Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ Notes
 - Copy `.env.example` to `.env` for local Django work; supply database credentials, GitHub tokens, and task runner settings as described in `docs/django_backend_plan.md`.
 - Run the stack through `docker compose` against PostgreSQL; we no longer support SQLite fallbacks for quick tests.
 - Keep secrets out of version control—store them in the `.env` file or your chosen secret manager.
+- Running the Docker checks from a **sandboxed** shell (an agent harness restricting filesystem
+  writes) needs `DOCKER_CONFIG` / `DOCKER_HOST` set, because Docker Desktop's credential helper
+  cannot start under the sandbox and takes every image pull down with it. Setup, verification and
+  undo are in `docs/sandboxed_docker_setup.md`. A normal terminal needs none of it.
 - **Every configurable setting MUST be wired through `base.py` AND documented in `.env.example` — no exceptions.** This is forgotten often; treat it as part of "done" for any setting change:
   1. Define it in `qb_site/qb_site/settings/base.py` as `FOO = os.getenv("FOO", <default>)` (with a short comment).
   2. Add `FOO=<default-or-blank>` to `.env.example` with a comment explaining it.

--- a/docs/design-decisions/053-on-demand-assignment-suggestions.md
+++ b/docs/design-decisions/053-on-demand-assignment-suggestions.md
@@ -1,0 +1,642 @@
+# On-Demand Assignment Suggestions (Reviewer-Initiated "What Should I Review?")
+
+> Status: **Planned** (living implementation plan). No code written yet. All feature flags will
+> default off, following the 046/050 staged-rollout discipline. The design below is calibrated
+> against a production measurement taken 2026-08-25 — see [Measured Baseline](#measured-baseline).
+
+## Context
+
+- Reviewer assignment today is entirely **push-based and scheduled**: `analyzer.refresh_reviewer_assignments`
+  computes a `{pr_number: login}` snapshot nightly, and `analyzer.propose_reviewer_assignments`
+  (design doc 050) either direct-assigns or opens an `AssignmentProposal` for it. A reviewer who
+  finishes their queue at 14:00 has no way to get more work until the next nightly run.
+- The acceptance gate (050) made assignment *consensual* but not *reviewer-initiated*. A reviewer
+  with capacity and time right now can only wait, or hunt the queueboard manually and use the
+  existing `assign` Zulip command on whatever they find — with no help from the matching engine
+  that already knows which PRs suit them.
+- **Push cannot reach a third of the reviewer base at all.** 19 of 57 reviewers have `auto_assign`
+  off and 3 are away (21 distinct, one being both), and the scheduled pipeline is by construction
+  silent toward every one of them. They are not marginal users of this feature — they are its
+  target population, and a pull surface is the only mechanism that can serve them. See
+  [Measured Baseline](#measured-baseline).
+- The matching logic to answer "what should **I** review?" already exists; it is just wired in the
+  opposite direction. `analyzer.services.reviewer_assignment_engine` answers *PR → reviewer*
+  (`_reviewer_candidate_state`, `suggest_reviewer_for_pr`), and `rank_prs_for_assignment` already
+  orders the queue by assignment priority. Inverting it needs **no engine change**: rank the
+  assignable PRs with the shared scorer, then walk that ranking keeping the PRs where the
+  requesting reviewer lands in the engine's own `available` list. This was verified against the
+  live engine over 29,412 (reviewer, PR) pairs with zero disagreements.
+- Two reviewer-facing surfaces already exist and are the natural homes: the Zulip bot
+  (`zulip_bot/commands/`) and the reviewer console (`qb_site/console/`, design doc 050).
+
+## Measured Baseline
+
+Measured 2026-08-25 against production (`leanprover-community/mathlib4`, default rule set `3`,
+queue snapshot 8 minutes old). Reproduce with `scripts/probe_053_suggestions.py` (read-only; see
+[Reproducing the measurement](#reproducing-the-measurement)). These numbers are what the design
+below is calibrated against; **re-run the probe before enabling the flags** to confirm the shape
+has not changed.
+
+**The candidate pool is large, and the scheduled pipeline places almost none of it.**
+
+| stage | PRs |
+| --- | --- |
+| queue | 746 |
+| − has an active assignee | −169 |
+| − assignment-forbidden label (`maintainer-merge`) | −49 |
+| − active `AssignmentProposal` | −12 |
+| **assignable pool** | **516** (463 carry a topic label) |
+| placed by the last nightly engine run | 11 |
+
+The gap is not a backlog against the apply cap (`ANALYZER_REVIEWER_ASSIGNMENT_APPLY_MAX_PER_REPO`
+is 50 in production and the engine produced only 11), and it is not missing area coverage (every
+topic label present in the pool has at least one interested reviewer). It is the supply side being
+throttled shut: **29 of 57 reviewers are at capacity** (median remaining capacity −0.01 — reviewers
+sit pinned exactly at their cap) and 21 are unavailable by preference. Those two groups overlap in
+one person, so 49 of 57 reviewers are throttled one way or the other; of the remaining 8, five
+already receive work from the nightly run and three are held back only by a narrow label set.
+
+**Every reviewer is reachable, by exactly one override.** Running the algorithm below for all 57
+reviewers, the population decomposes cleanly — the groups are disjoint, verified pairwise:
+
+| blocker | reviewers | unlocked by |
+| --- | --- | --- |
+| none — the nightly run can already assign them | 5 | — |
+| availability (`auto_assign=false` / `away_until`) | 20 | the request's availability override |
+| capacity | 29 | the request's capacity override |
+| narrow label set | 3 | an explicit label override |
+| unreachable under any override | **0** | — |
+
+**There is plenty to suggest.** With availability and capacity overridden and the reviewer's own
+labels, the median reviewer has **69** eligible PRs; 45 of 57 have at least 10, and only 7 have
+three or fewer. A broad label override yields the whole 463-PR labelled pool.
+
+**Why reviewers are skipped**, over all 29,412 (reviewer, PR) pairs, with real preferences and no
+overrides:
+
+| reason | pairs | share |
+| --- | --- | --- |
+| `no_area_match` | 20,961 | 71.3% |
+| `no_topic_label` | 3,021 | 10.3% |
+| `at_capacity` | 2,357 | 8.0% |
+| `auto_assign_off` | 1,588 | 5.4% |
+| `outranked` | 757 | 2.6% |
+| *eligible* | 354 | 1.2% |
+| `away` | 156 | 0.5% |
+| `authored` | 110 | 0.4% |
+| `excluded` (opt-out / cooldown) | 108 | 0.4% |
+
+Consequences that shaped the design:
+
+- **`no_area_match` dominates at 71.3%.** The label override is the highest-value part of this
+  feature, not a convenience — it is the difference between 0 and the whole pool for a reviewer
+  whose interests have drifted from their stored `preferred_labels`.
+- **`outranked` is worth its tally, for a sharper reason than "one label loses to two".** It is
+  757 pairs, but the meaningful denominator is the 5,430 pairs where the reviewer matched an area
+  at all — **13.9%**. It is also *concentrated*: the median pool PR carries exactly one topic label
+  (mean 1.01), so at most 58 PRs (≤11% of the pool) can outrank anybody. On those few multi-label
+  PRs the `max_score` contest eliminates most matching reviewers at once.
+- **Label supply and demand are badly skewed** even where coverage exists: `t-combinatorics` has 76
+  pool PRs against 4 interested reviewers (19:1), `t-order` 7:1, `t-ring-theory` 5:1, `t-algebra`
+  4.5:1. The scarcity-first ranking is doing real work.
+- **The request costs ~476 ms, and 83% of it is one payload read.** Measured separately with
+  `scripts/probe_053_payload_cost.py` (5 repeats, warm connection):
+
+  | phase | mean | share |
+  | --- | --- | --- |
+  | snapshot payload load | 411 ms | 82.9% |
+  | `prepare_assignment_inputs` (DB) | 28 ms | 5.6% |
+  | rank the pool | 24 ms | 4.8% |
+  | walk the whole pool | 17 ms | 3.4% |
+  | load line | 16 ms | 3.3% |
+  | **end-to-end** | **495 ms** (median 476, range 340–687) | |
+
+  The payload is 5.62 MB TOAST-compressed on disk and 13.18 MB as JSON text (2.34× compression).
+  Standalone, the ORM read is 267 ms median, splitting roughly two-thirds Postgres fetch +
+  decompress + wire (198 ms) and one-third `json.loads` (88 ms) — neither reducible at the call
+  site. `.only("payload")` is worth nothing (267 ms vs 270 ms for the full row); do not bother.
+  **All engine compute together is 85 ms**, so the algorithm is not the thing to optimise.
+- **Memory is the constraint to watch, not latency.** One held payload is a 28.8 MB Python object
+  graph (2.19× the JSON text — lower than a naive guess, because the document is dominated by long
+  strings rather than deep structure), but loading it peaks at 81.6 MB transient with the raw
+  buffer and parsed graph alive together, and process RSS rose 63.5 MB across a single load. Peak
+  RSS for the whole probe run was 259 MB. Steady state is comfortable; the transient spike is what
+  could bite if several console requests load payloads concurrently on a small dyno.
+
+Context on the surrounding pipelines, from the same run: 789 `ReviewerAssignmentApplication` rows
+all-time (327 in the last 30 days, ~12/day); proposals stand at 15 accepted / 60 declined / 26
+expired, though only 6 reviewers are in `confirm` mode, so that ratio is 6 people's behaviour and
+is *not* load-bearing evidence for this design; 1,746 active `ReviewerOptOut` rows, of which only
+114 exclusions land on 76 PRs still in the pool.
+
+## Goals / Non-Goals
+
+**Goals**
+- A reviewer can ask, on demand, for a fixed number of open PRs they could review — from Zulip or
+  from the console.
+- The suggestion may be scoped to an explicit **set of labels**, which *replaces* the reviewer's
+  stored `preferred_labels` for that request (so a reviewer can ask for work in an area they do not
+  normally take).
+- An explicit request overrides the reviewer's own **push-throttle preferences** — `away_until`,
+  `auto_assign=false`, and `maximum_capacity`. All three configure how much the *scheduled*
+  pipeline sends; none of them is a statement about what the reviewer wants when they are the one
+  asking.
+- Claiming is one step from the suggestion: the existing `assign` command in Zulip, a button in the
+  console.
+- Suggestions come from the *same* candidate pool the nightly builder uses, so they can never offer
+  something the scheduled run would refuse.
+
+**Non-Goals**
+- No new `AssignmentProposal` rows. An on-demand request is not routed through the acceptance gate
+  — the reviewer is already asking, so a propose→accept round trip is pure friction (see
+  Alternatives). Design doc 050 remains the mechanism for *system-initiated* assignment.
+- No reservation/hold on a suggested PR (see Invariant 8).
+- No changes to the nightly compute/propose pipeline, the engine, or `ReviewerPreference`.
+- No new Zulip mutation command. Claiming from Zulip reuses `assign`.
+- No persistence of any kind on the read path — a suggestion is computed and discarded (Invariant 1).
+
+## Proposed Design
+
+### One read-only service, two renderers
+
+New module `qb_site/analyzer/services/assignment_suggestions.py`. It is the single authority for
+"which open PRs could this reviewer take right now, and why not the rest". Both surfaces render its
+output; neither re-derives eligibility.
+
+```python
+@dataclass(frozen=True)
+class SuggestedPR:
+    pr_number: int
+    title: str
+    url: str
+    author_login: str
+    topic_labels: list[str]
+    matched_labels: list[str]        # intersection with the effective label set
+    queue_age_seconds: float | None
+    available_reviewer_count: int    # scarcity, from the ranking scorer's `details`
+    load_weight: float               # what claiming it would add to the reviewer's load
+
+
+@dataclass(frozen=True)
+class SuggestionResult:
+    repository_id: int
+    reviewer_login: str              # normalized
+    effective_labels: list[str]      # the override set, else the reviewer's preferred_labels
+    label_override: bool
+    unknown_labels: list[str]        # requested labels that are not topic labels in this repo
+    load: ReviewerLoad | None        # from the reviewer's REAL capacity — never the override
+    suggestions: list[SuggestedPR]
+    skipped: dict[str, int]          # reason -> count over the assignable pool
+    snapshot_generated_at: datetime | None
+    status: str                      # ok | no_snapshot | not_a_reviewer | no_labels | none_eligible
+
+
+def suggest_prs_for_reviewer(
+    repository: Repository,
+    reviewer_login: str,
+    *,
+    labels: Sequence[str] | None = None,
+    limit: int | None = None,        # None -> ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT
+    now: datetime | None = None,
+) -> SuggestionResult: ...
+```
+
+Algorithm:
+
+1. **Read the cached queue snapshot** for the repo's default rule set. Like
+   `analyzer.services.reviewer_load`, this service **never builds** a snapshot — no snapshot means
+   `status="no_snapshot"` and no suggestions, never a fabricated empty list.
+2. **Assemble the candidate pool** via `_prepare_assignment_inputs` (promoted to a public
+   `prepare_assignment_inputs`). This is the load-bearing reuse: it already applies the
+   active-assignee filter, the assignment-forbidden label filter, the active-proposal exclusion, the
+   per-PR opt-out and expired-proposal-cooldown exclusions, and folds pending-proposal load into
+   reviewer weights. Suggestions therefore share one pool with the nightly builder by construction.
+3. **Build the request profile.** Locate the requester's `ReviewerProfile` in `inputs.reviewers`
+   (absent ⇒ `status="not_a_reviewer"`) and replace it, in place, with a `dataclasses.replace` copy:
+   - `auto_assign=True`, `temporary_break=False` — an explicit request overrides availability;
+   - `maximum_capacity=sys.maxsize` — an explicit request overrides the capacity throttle
+     unconditionally (Invariant 7);
+   - `preferred_labels` / `preferred_labels_lower` ← the requested label set, when one is given.
+
+   Every downstream engine call then sees the override. **The engine itself is not modified**, and
+   the substitution is the whole of the "explicit request" semantics — one seam, not a special case
+   threaded through the engine.
+4. **Compute the load line** from the *same* payload (`reviewer_load_for(..., snapshot_payload=payload)`).
+   `build_reviewer_loads` rebuilds the catalog from `ReviewerPreference`, so it reports the
+   reviewer's **real** `maximum_capacity`, not the `sys.maxsize` override — which is the point: the
+   load line is now the *only* capacity signal the reviewer gets, and it must be true (Invariant 7).
+5. **Rank** `inputs.assignable_queue_prs` with the shared `rank_prs_for_assignment` and the default
+   scorer. The ranking is scarcity-first (fewest available reviewers, least remaining capacity),
+   then queue age, then `feat:` priority, then PR number. That is the right order *among the PRs a
+   given reviewer can take* — the PR that most needs this reviewer comes first. It is worth being
+   honest that it is not a per-reviewer ordering: because scarcity-first front-loads PRs that are
+   scarce precisely because few reviewers match them, the median reviewer's first eligible PR sits
+   at rank ~78 of 516. Walking is cheap — 17 ms for the entire pool against a ~476 ms request — so
+   this costs nothing, and the early-stop at `limit` is not an optimisation worth reasoning about:
+   it can save at most 17 ms of a request dominated by the payload read.
+6. **Walk the ranking**, and for each PR call `suggest_reviewer_for_pr_with_trace` with the override
+   catalog. Keep the PR when the normalized requester login appears in `trace["available"]`;
+   otherwise record a skip reason. Stop at `limit`. The trace's `picked` field is **ignored** — this
+   service reads `available` / `potential` / `filtered` only, and never the random draw. This is
+   what makes results reproducible (Invariant 2).
+7. Return the top `limit` suggestions plus the skip tally.
+
+### Skip tally ("why not more?")
+
+Derived from the trace's existing `filtered` buckets plus a little local classification, counted
+across the assignable pool. Reasons are attributed in the engine's own evaluation order, so each
+pair is counted once against the *first* rule that excluded it:
+
+| reason | meaning |
+| --- | --- |
+| `no_topic_label` | the PR carries no topic label at all (engine reason `missing-topic-label`) |
+| `authored` | the requester is the PR author |
+| `conflict_of_interest` | the requester lists the author as a conflict |
+| `no_area_match` | none of the effective labels intersect the PR's topic labels |
+| `outranked` | the requester matched, but another reviewer matched *more* labels, so the engine's `max_score` contest dropped them |
+| `excluded` | active per-PR `ReviewerOptOut`, or expired-proposal cooldown |
+
+There is deliberately **no `at_capacity` row**: the requester's capacity is always overridden, so it
+can never be the reason *they* were skipped.
+
+`outranked` is the non-obvious one and the reason this tally is worth building: without it, an empty
+or short result looks like a bug. It fires on 13.9% of the pairs where a reviewer matched an area,
+concentrated on the ≤11% of pool PRs that carry more than one topic label — see
+[Measured Baseline](#measured-baseline).
+
+### Zulip surface
+
+New command `suggest-prs` (aliases `next-pr`, `suggest-pr`), registered like every other command in
+`zulip_bot/commands/`.
+
+```
+suggest-prs [<owner/repo>] [<label> ...]
+```
+
+- No repo argument: one section per repository where the sender has a `ReviewerPreference`, matching
+  how `assigned-prs` already behaves. With a repo argument: that repo only.
+- Remaining tokens are the label override set (capped by `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS`;
+  unknown/non-topic labels are reported back rather than silently yielding nothing).
+- **Reply in place** (`CommandResult(content=...)`), not a DM. The content is not sensitive, and —
+  the deciding argument — the natural next step is `assign #12345`, which is itself an in-place
+  command. Splitting the two halves of one flow across a DM and a channel would be worse than
+  either. This follows `assign` / `console`, not `assigned-prs` / `prefs`.
+- Shows `ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT` (5), not the full service limit. Ten
+  multi-line blocks would dominate a shared channel; the console link below carries the rest.
+- Reply shape: the load line, then **one line per PR** (linked number + title + topic labels — the
+  richer card with queue age and scarcity is the console's job), then a footer with:
+  - the follow-up command, `assign #12345`;
+  - `snapshot_generated_at`, because the reply is a permanent channel message that will still be
+    sitting there tomorrow listing PRs that have since been claimed or merged, while the console
+    page is always live;
+  - a link to the console for more (see below).
+- Still chunked through the shared `split_message_chunks` (`zulip_bot/services/zulip_client.py`).
+  Five one-line entries land far inside Zulip's 10,000-character cap, so this is belt-and-braces
+  rather than a live concern — the justification is the measured size, not the smallness of the limit.
+- Empty result renders the skip tally as a one-line explanation.
+
+**The console link.** Built with `build_site_url(reverse("console:suggestions"))` — a stable,
+token-less URL, exactly like `commands/console.py`. No signed link is needed: design doc 052's
+reasoning for why `close-pr` / `label-pr` require signed expiring tokens (they carry a target PR
+plus a permission decision, for audiences wider than reviewers) does not apply, because suggestions
+are reviewer-only and that is already the console's admission rule.
+
+Carry the request shape in the query string — `?repo=<id>&labels=t-algebra,t-topology` — so that
+"more suggestions" means more of *the same* question. Without it, a reviewer who asked for
+`t-algebra` in Zulip lands on an unfiltered console page and the continuation silently becomes a
+different query. The params are safe on a token-less URL because they pre-fill only repo and labels;
+the login still comes from the session and never from the request (Invariant 6). Validate them
+server-side regardless: `MAX_LABELS` applies to the query string too, and unknown labels already
+have somewhere to go in `unknown_labels`.
+
+**Footer wording must stay indefinite** — "more suggestions", never "the next 5" or "5 more like
+these". The prefix property (Invariant 2) holds only within one snapshot generation, and
+`ANALYZER_QUEUEBOARD_SNAPSHOT_PERIOD_SECONDS` is 300, so a reviewer who clicks through ten minutes
+later may legitimately see a different set. In practice the head of the list moves slowly — the
+dominant sort terms are `available_reviewer_count` and `total_remaining_capacity`, which change only
+when loads change, while `queue_age_seconds` sits fourth and drifts monotonically for every PR at
+once — but the copy must not promise what the refresh can break.
+
+**Claiming from Zulip reuses the existing `assign` command.** It already self-assigns when no
+`@**user**` is mentioned (`assignment_command_parser.py`), already refuses senders without a
+`ReviewerPreference` for the repo (`missing_preference`), is already gated by
+`ZULIP_ASSIGNMENT_MUTATIONS_ENABLED` and `ZULIP_COMMAND_POLICY`, and already enqueues a per-PR sync.
+No new mutation surface, flag, or permission path is introduced on the Zulip side.
+
+### Console surface
+
+- **New page** `/console/suggestions/` (`console:suggestions`), reached from a "Find PRs to review"
+  link on the home dashboard — including in the empty state, which currently offers a dead end
+  ("no proposals, no assigned PRs"). A separate page, not a home section — but note the measurement
+  weakens the *cost* half of that argument, so do not lean on it: the home already loads the same
+  13 MB payload through `reviewer_load_with_breakdown`, so a home section reusing it would add only
+  the ~85 ms engine run, where a separate page pays a fresh ~476 ms. The decision stands on the
+  other two grounds: a label-override control plus a multi-select claim form is a page rather than a
+  panel, and the engine should not run for every reviewer on every home render whether or not they
+  came looking for work.
+- GET renders the same `SuggestionResult` per repo at `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT` (10),
+  with a label-override control. Accepts `?repo=` and `?labels=` to pre-fill the form from a Zulip
+  footer link. Each suggestion carries an "Assign me" button; multiple may be selected.
+- POST `console:claim` (`/console/suggestions/claim/`) takes `repo_id` + `pr_numbers[]` and, per PR,
+  **re-runs `suggest_prs_for_reviewer` and verifies the number is still eligible** before writing
+  (Invariant 6), then goes through the 046 mutation path `assign_reviewer_and_record` (GitHub assign
+  + `ReviewerAssignmentApplication` + `sync_pr`). Partial failures are contained and rendered as an
+  assigned/failed split, exactly like `console:unassign`'s `unassigned.html`.
+- The login assigned is **always the session reviewer's own**, never taken from the request — the
+  same invariant that makes `console:unassign` safe.
+- Unassigning needs no new work: the home dashboard's assigned-PR roster is already a self-unassign
+  form behind `ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED`.
+
+## Subtleties / Invariants
+
+1. **Suggestion is read-only and nothing is persisted.** No proposal rows, no GitHub calls, no
+   snapshot builds, no `ReviewerPreference` writes, and no record that a suggestion was ever made.
+   A suggestion is a pure function of (snapshot payload, live preference/proposal/opt-out state),
+   computed and discarded. Safe to invoke from any surface, any number of times, by anyone entitled
+   to their own suggestions. The cost of this choice is that assignment provenance cannot be
+   reconstructed later — see Deferred Follow-Ups.
+2. **Results are reproducible, and Zulip's list is a strict prefix of the console's.** Given one
+   snapshot generation and unchanged live state, the same request returns the same PRs in the same
+   order: the ranking sort key ends in `pr_number` so it is a total order with no ties; the service
+   tests membership in `available` and ignores `picked`, so the weighted random draw never enters;
+   and the catalog arrives through a stable sort over `order_by("user__github_login")`. Both
+   surfaces walk the same ranking with different `limit`s, so the Zulip 5 are the first 5 of the
+   console 10. This is what makes "more suggestions on the console" coherent — and it expires with
+   the snapshot (300 s), which is why the copy stays indefinite.
+3. **The request affects only the requester, and only toward more work.** That is precisely what
+   makes overriding `away_until`, `auto_assign=false`, and `maximum_capacity` safe: a reviewer
+   cannot use this to change anyone else's state, or to reduce their own obligations.
+4. **Push-throttle preferences are overridable; correctness rules are not.** Overridable, because
+   all three configure how much the *scheduled* pipeline sends: `away_until`, `auto_assign`,
+   `maximum_capacity`. Never overridden: conflict-of-interest, per-PR `ReviewerOptOut`,
+   expired-proposal cooldown, authorship, assignment-forbidden labels, PRs that already carry an
+   assignee, and PRs held by an active `AssignmentProposal`. The first two are the reviewer's own
+   standing decisions about *specific* people and PRs, not a statement about when or how much they
+   are free.
+5. **One candidate pool.** Suggestions must go through `prepare_assignment_inputs`. A second,
+   hand-rolled filter chain here would drift from the builder and start offering PRs the nightly run
+   refuses. New exclusion rules belong there, not at a call site.
+6. **A posted PR number is re-verified against a fresh suggestion run before any GitHub write, and
+   the login always comes from the session.** Without the re-check the console claim endpoint
+   degrades into a general-purpose self-assign API that bypasses conflict-of-interest and opt-out
+   rules. Because the request carries no eligibility-affecting intent (no `allow_over_capacity` to
+   round-trip), the re-check is a pure re-evaluation of the same inputs: the only things that can
+   legitimately make it disagree with the offer are real state changes.
+7. **Capacity is reported, never enforced.** An explicit request overrides `maximum_capacity`
+   unconditionally — asking *is* the consent, and requiring a second signal would have meant a
+   dead end for 29 of 57 reviewers on the Zulip surface, which has no toggle to offer. The load
+   line takes over as the honest capacity signal, so it is load-bearing UI rather than decoration:
+   it must be rendered on both surfaces, and it must come from `reviewer_load_for` (real
+   `ReviewerPreference.maximum_capacity`) and never from the overridden profile — otherwise it
+   renders `Load: 10 / 9223372036854775807`. `format_load_line` already produces the honest
+   `Load: 10 / 10 ⚠ at capacity`. The real second signal is the reviewer's decision to claim, taken
+   with that line in front of them.
+8. **No hold, and no pretence of one.** Two reviewers can be offered the same PR and both claim it.
+   GitHub assignees are a set, so the outcome is two assignees — legal, visible, and self-correcting
+   (the next nightly run drops an assigned PR from the pool). The claim result surfaces any
+   co-assignee rather than implying exclusivity. Reserving a PR would mean an `AssignmentProposal`
+   row as a mutex, which reintroduces the machinery this design deliberately avoids.
+9. **The label override loses the `max_score` contest like anyone else — when it can.** Asking for
+   `t-algebra` does not promote the requester above a reviewer who matches two of the PR's labels.
+   Note the asymmetry this creates, and do not mistake it for a bug: a *broad* override cannot be
+   outranked at all, because matching every label on a PR always ties `max_score`. The invariant
+   therefore bites narrow requests only. Keeping the engine's contest honest is worth the occasional
+   surprising empty result — which is exactly what the `outranked` tally exists to explain.
+10. **Consistent numbers from one payload read.** The load line, the per-PR load contributions, and
+    the eligibility decisions all derive from the same snapshot payload in one call, so the parts
+    cannot disagree with the whole.
+
+## Interactions With Existing Pipelines
+
+- **Nightly builder:** a claimed PR gains an assignee, so `_filter_prs_without_active_assignee`
+  drops it from the next run, and the claimer's higher load reduces what the engine gives them.
+  No explicit coupling is required — the daily recompute absorbs on-demand activity the same way it
+  absorbs manual assignment.
+- **Over-capacity claims self-limit.** `_reviewer_candidate_state` requires `remaining > 0`, so a
+  reviewer who claims their way to 13/10 receives nothing from the scheduled run until they drain
+  back under their cap. This is the mechanism that makes removing the capacity gate safe: the
+  reviewer can take on more, but only deliberately and one request at a time, and the push pipeline
+  stops adding to the pile automatically.
+- **Acceptance gate (050):** PRs with an active proposal are already excluded from the pool, so a
+  suggestion can never collide with a pending proposal — including the requester's own, which is
+  already presented to them on the console home. Pending-proposal load still contributes to the
+  displayed load line via `add_pending_proposal_load`, but no longer gates what the requester is
+  offered; that is intended, not an oversight.
+- **Opt-outs:** the syncer clears an active `ReviewerOptOut` when a reviewer appears as an assignee
+  (`pr_sync_service.py`, both the timeline-event and assignee-diff paths), so a claim self-heals
+  stale opt-out state once the enqueued sync lands.
+- **Stale-assignment backstop:** the 21-day auto-unassign sweep applies to claimed PRs unchanged.
+- **Snapshot cadence:** `ANALYZER_QUEUEBOARD_SNAPSHOT_PERIOD_SECONDS` is 300, which sets the
+  lifetime of a suggestion list (Invariant 2). Note also that the pool filters read *snapshot*
+  assignees, so a PR claimed by someone else stays in the pool until the next snapshot lands.
+- **Audit asymmetry (accepted, with a follow-up):** a console claim writes a
+  `ReviewerAssignmentApplication` row via the 046 path; a Zulip claim through `assign` does not,
+  because `zulip_bot/services/assignment_execution.py` calls `GitHubAssignmentClient` directly. This
+  is pre-existing rather than introduced here, but this feature makes Zulip self-assignment routine,
+  which raises its cost. See Deferred Follow-Ups.
+
+## Implementation Plan (Chunks)
+
+Each chunk is independently testable. Run `uv run ruff check .` and `uv run ruff format .` before
+every commit; the canonical full run is `bash scripts/repo_check_compose.sh`.
+
+1. **Service.** `analyzer/services/assignment_suggestions.py`; promote `_prepare_assignment_inputs`
+   to a public `prepare_assignment_inputs`. This is a straight rename — the only three references
+   are all inside `reviewer_assignment.py` itself (its definition plus
+   `build_reviewer_assignment_trace` and `ReviewerAssignmentBuilder.build`), so no alias is needed.
+   `scripts/probe_053_suggestions.py` imports the private name and must be updated in the same
+   commit, or re-running the baseline will fail on import. Pure unit tests over fixture snapshot
+   payloads.
+2. **Settings.** All flags/tunables through `settings/base.py` **and** `.env.example` in the same
+   commit (root AGENTS.md rule — this is the step most often forgotten, and skipping either half
+   means the setting either has no effect in production or is undiscoverable for new deployments).
+3. **Zulip command.** `commands/suggest_prs.py` + arg parsing + rendering; the console footer link
+   with `?repo=`/`?labels=`; registry-dispatch coverage; `ZULIP_COMMAND_POLICY` note;
+   `zulip_bot/AGENTS.md` update.
+4. **Console.** `console:suggestions` + `console:claim`, templates, console-owned CSS built on the
+   shared tokens, `?repo=`/`?labels=` pre-fill, home entry point (including the empty state); view
+   tests mocking `assign_reviewer_and_record`; `console/AGENTS.md` update.
+5. **Docs.** `analyzer/AGENTS.md` service list, this doc's finalization into ADR shape.
+
+## Validation Plan
+
+Unit tests (fixture payload, no GitHub/Zulip):
+- ordering matches the scheduled ranking; `limit` respected;
+- **prefix property**: the same request at `limit=5` returns exactly the first five of `limit=10`
+  (Invariant 2) — this is the promise the Zulip footer's console link makes;
+- **determinism**: two identical calls against the same payload return identical ordered results,
+  proving the engine's random draw never leaks in through `picked`;
+- label override replaces `preferred_labels`; unknown labels reported; `MAX_LABELS` enforced;
+- `away_until`, `auto_assign=false` and `maximum_capacity` are all overridden; conflict, authorship,
+  opt-out and cooldown are **not**;
+- **the load line reports the reviewer's real capacity**, not the `sys.maxsize` override — an
+  at-capacity reviewer gets both suggestions *and* `Load: 10 / 10 ⚠ at capacity` (Invariant 7);
+- each skip-tally reason is produced by a case that only triggers that reason, `outranked` included;
+  and no case ever produces an `at_capacity` skip for the requester;
+- a broad label override is never `outranked` (Invariant 9);
+- `no_snapshot` returns no suggestions rather than an empty-looking success.
+
+Console view tests (existing `console/tests/test_views.py` patterns, session seeded, GitHub mocked):
+- claim assigns via the 046 path and enqueues a sync;
+- a posted PR number that is **not** in a fresh eligible set is rejected (Invariant 6);
+- a claim for another reviewer's login is impossible (login comes from the session);
+- `?repo=`/`?labels=` pre-fill the form and are validated, not trusted;
+- partial failure renders the assigned/failed split.
+
+Zulip tests: registry dispatch, the 5-item limit, footer contents (assign hint, snapshot timestamp,
+console link carrying the requested labels), and the empty-result tally rendering.
+
+Canonical full run stays `bash scripts/repo_check_compose.sh` (console is step `[12/12]`).
+
+## Operational Notes
+
+Settings (all `settings/base.py` + `.env.example`):
+
+| setting | default | purpose |
+| --- | --- | --- |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED` | off | master switch for the read path on both surfaces |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED` | off | the console's GitHub write |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT` | 10 | service default; what the console renders |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT` | 5 | surface override for the in-channel reply |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS` | 5 | cap on the label override set (form and query string alike) |
+
+`suggest_prs_for_reviewer(limit=None)` falls back to `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT`, so the
+Zulip setting is a surface override rather than a second parallel knob.
+
+- Zulip claiming needs no new flag: `assign` is already gated by `ZULIP_ASSIGNMENT_MUTATIONS_ENABLED`
+  and `ZULIP_COMMAND_POLICY`.
+- Console claiming needs the `assign_pr` operation token (`queueboard-assignment` app), already
+  configured for the 046/050 paths.
+- Rollout: re-run `scripts/probe_053_suggestions.py` to confirm the baseline still holds, enable the
+  read path first on both surfaces (harmless — read-only), confirm the suggestions look sane against
+  the queueboard, then enable the console claim flag.
+- **Cost:** a request is ~476 ms, of which ~411 ms is the snapshot payload read and ~85 ms is all
+  engine compute combined (see [Measured Baseline](#measured-baseline)). That is acceptable for a
+  deliberate "find me work" page and is not a blocker, but it is slow enough to be worth fixing —
+  and it means **the cache to build is not the one an earlier draft of this doc proposed**. Caching
+  the *result* per `(repo, reviewer, label set, cache_key)` targets the cheap 17% and only helps a
+  reviewer who repeats the identical request. The expensive 83% is repo-scoped and completely
+  reviewer-independent: cache the **payload** per `(repo_id, cache_key, generated_at)` and every
+  request in the repo is served from it, cutting the page to roughly its compute cost. Budget
+  ~29 MB resident per cached payload per worker process, and note this is shared infrastructure
+  rather than a 053 optimisation — `reviewer_load._latest_snapshot_payload` means the console home
+  already pays the identical 411 ms today. Do not optimise the engine; there is nothing there.
+
+### Reproducing the measurement
+
+```bash
+APP=<heroku-app>
+
+# cheap pre-check, no dyno
+heroku pg:psql -a "$APP" -f scripts/probe_053_precheck.sql
+
+# eligibility probe (read-only; reviewer logins pseudonymised unless --no-anon)
+PAYLOAD=$(gzip -9c scripts/probe_053_suggestions.py | base64 | tr -d '\n')
+heroku run --no-tty --app "$APP" -- bash -c \
+  "echo '$PAYLOAD' | base64 -d | gunzip > /tmp/probe.py && PYTHONPATH=\$PWD/qb_site:\$PWD python /tmp/probe.py"
+
+# payload/latency probe (read-only)
+PAYLOAD=$(gzip -9c scripts/probe_053_payload_cost.py | base64 | tr -d '\n')
+heroku run --no-tty --app "$APP" -- bash -c \
+  "echo '$PAYLOAD' | base64 -d | gunzip > /tmp/cost.py && PYTHONPATH=\$PWD/qb_site:\$PWD python /tmp/cost.py --repeats 5"
+```
+
+Each writes one JSON object between `===QB-PROBE-053-JSON-BEGIN===` / `===QB-PAYLOAD-COST-JSON-BEGIN===`
+and the matching `...-END===` marker.
+
+The eligibility probe's `A_as_is` pass cross-checks its own skip classifier against the live
+`suggest_reviewer_for_pr_with_trace` on every (reviewer, PR) pair and reports `engine_mismatches` —
+that count must be 0, or the classifier has drifted from the engine.
+
+The cost probe times *queryset evaluation*, not attribute access: a `JSONField` is decoded when the
+queryset is evaluated, so timing `snapshot.payload` afterwards measures nothing. An earlier draft of
+this doc reported `payload_read_seconds: 0.0` for exactly that reason. If the dyno is OOM-killed,
+re-run with `--size=standard-2x` — `tracemalloc` adds overhead at the moment the payload loads.
+
+## Deferred Follow-Ups
+
+- **Suggestion provenance, which requires the Zulip audit fix first.** These look like two
+  independent follow-ups and are not. Answering "how many assignments came from a reviewer asking
+  versus the nightly run?" needs a provenance marker on `ReviewerAssignmentApplication` — but
+  Zulip's `assign` writes no such row at all, so a provenance field added alone would silently
+  measure console claims only and read as "nobody uses Zulip for this". Routing `assign`'s
+  **self**-assign through `assign_reviewer_and_record` is the prerequisite, not a sibling task.
+  Shipping without either is a deliberate choice, not an oversight.
+- **Cache the snapshot payload per `(repo_id, cache_key, generated_at)`.** The single highest-value
+  performance change available, worth ~411 ms of a ~476 ms request, and it benefits the console home
+  and `pr_info` as much as this feature. Deliberately out of scope here: it belongs to
+  `analyzer.services.reviewer_load`, not to a caller.
+- `why-not <PR url>` — a reviewer-facing single-PR explainer over the same trace machinery. Falls
+  out of the skip tally almost for free once the service exists.
+- `away` / `back` Zulip commands to set and clear `away_until` without opening the console — the
+  natural companion to "I'm back, give me a PR" (today this feature deliberately *ignores* a stale
+  `away_until` rather than fixing it).
+- A user-supplied count, if the fixed limits prove wrong in practice.
+
+## Alternatives (discarded)
+
+- **Gate the capacity override behind an explicit second signal** (an `allow_over_capacity` flag, a
+  console checkbox). Discarded on the measurement: 29 of 57 reviewers are at capacity, so the second
+  signal would be needed by a majority of reviewers most of the time — a rubber stamp rather than a
+  meaningful confirmation. Worse, the Zulip surface has nowhere to put such a toggle, so
+  `suggest-prs` would have been a dead end for exactly those reviewers. `maximum_capacity` is a
+  push-throttle like `auto_assign` and `away_until`, and belongs in the same bucket (Invariant 4);
+  the load line carries the honest signal instead (Invariant 7).
+- **Route on-demand requests through the acceptance gate** (create `AssignmentProposal` rows the
+  reviewer then accepts on the console). Reuses 050 wholesale, but a reviewer who just asked for
+  work does not need to be asked whether they want it, and in Zulip it is strictly *more* friction:
+  the proposal still has to be answered in the console, so the round trip the console flow avoids
+  comes back through the side door. "Park work for later" is already what the nightly propose
+  pipeline does; it does not need an on-demand twin.
+- **Asymmetric surfaces** (console assigns directly, Zulip creates proposals). Two meanings for one
+  verb, and it pushes the Zulip user to a second surface to finish what they started.
+- **A dedicated Zulip claim command** (`claim` / `take-pr`) routed through the shared service, for
+  eligibility re-checking and 046 audit rows on the Zulip side too. Rejected for this iteration as
+  duplicate surface: `assign` already does self-assignment with the right permission model. Revisit
+  together with the provenance follow-up above.
+- **Reserving a suggested PR** with a short-lived `AssignmentProposal` acting as a mutex. Solves a
+  race whose worst outcome (two assignees on one PR) is legal, visible and self-correcting, at the
+  cost of rows to create, expire and clean up on every failure path.
+- **Modifying the engine to take a "requesting reviewer" parameter.** The override-profile
+  substitution achieves the same thing with no change to a module that the nightly builder, the
+  trace, and area stats all depend on.
+- **One shared limit across both surfaces.** Ten one-line entries would still fit a Zulip message,
+  but ten multi-line blocks dominate a shared channel, and truncating to a terser render alone would
+  leave the Zulip user with no path to the remainder. Two limits plus a console link costs one extra
+  setting and gives the reviewer somewhere to go.
+
+## Progress Notes
+
+- **2026-08-25** — Production measurement taken before writing any code (see
+  [Measured Baseline](#measured-baseline)); probe committed as `scripts/probe_053_suggestions.py`
+  and `scripts/probe_053_precheck.sql`. Four design changes followed from it:
+  1. the capacity override became unconditional and
+     `ANALYZER_ASSIGNMENT_SUGGESTIONS_ALLOW_OVER_CAPACITY` was dropped, along with the
+     `allow_over_capacity` parameter, the console checkbox, the `at_capacity` status and its
+     skip-tally row;
+  2. the limit went 3 → 10, split into a console 10 and a Zulip 5 with a console link for the rest;
+  3. the ranking justification in step 5 was softened, and Invariant 9 gained the broad-override
+     asymmetry — both facts the measurement surfaced;
+  4. provenance and the Zulip audit asymmetry were merged into one follow-up, because a provenance
+     field alone would measure only half the claims.
+  Also verified: the inverted-engine approach agrees with the live engine on all 29,412
+  (reviewer, PR) pairs.
+- **2026-08-25 (later)** — measured the one number the baseline had left open: the snapshot payload
+  load, via `scripts/probe_053_payload_cost.py`. A request is ~476 ms and the payload read is 83% of
+  it; all engine compute together is 85 ms. Two conclusions changed the doc. The cost note no longer
+  says caching is premature — it is worth doing, but the cache must be keyed on
+  `(repo_id, cache_key, generated_at)` around the *payload*, not on
+  `(repo, reviewer, labels, cache_key)` around the *result*, because the expensive part is
+  repo-scoped and reviewer-independent. And memory joined latency as a thing to watch: 28.8 MB
+  resident per held payload, but an 81.6 MB transient peak while loading it.
+
+## Related Decisions
+
+- `020-reviewer-opt-outs-and-timeline-assignments.md`
+- `022-zulip-prefs-form-design.md`
+- `026-zulip-assign-unassign-and-github-app-tokens.md`
+- `028-reviewer-queue-nudges-v1-daily-report.md`
+- `037-reviewer-assignment-policy-simulation-and-priority-planning.md`
+- `046-apply-reviewer-assignments-in-django.md`
+- `050-reviewer-assignment-acceptance-gate.md`
+- `052-session-authenticated-pr-action-pages.md` — why the console link here needs no signed token

--- a/docs/design-decisions/053-on-demand-assignment-suggestions.md
+++ b/docs/design-decisions/053-on-demand-assignment-suggestions.md
@@ -1,8 +1,9 @@
 # On-Demand Assignment Suggestions (Reviewer-Initiated "What Should I Review?")
 
-> Status: **Planned** (living implementation plan). No code written yet. All feature flags will
-> default off, following the 046/050 staged-rollout discipline. The design below is calibrated
-> against a production measurement taken 2026-08-25 — see [Measured Baseline](#measured-baseline).
+> Status: **Implemented** (2026-08-25), feature-flagged and dark: all `ANALYZER_ASSIGNMENT_SUGGESTIONS_*`
+> flags default off, following the 046/050 staged-rollout discipline. See the rollout steps under
+> [Operational Notes](#operational-notes). The design was calibrated against a production
+> measurement taken 2026-08-25 — see [Measured Baseline](#measured-baseline).
 
 ## Context
 
@@ -249,6 +250,7 @@ pair is counted once against the *first* rule that excluded it:
 
 | reason | meaning |
 | --- | --- |
+| `already_assigned` | the requester is already an assignee of the PR (see note below) |
 | `no_topic_label` | the PR carries no topic label at all (engine reason `missing-topic-label`) |
 | `authored` | the requester is the PR author |
 | `conflict_of_interest` | the requester lists the author as a conflict |
@@ -258,6 +260,13 @@ pair is counted once against the *first* rule that excluded it:
 
 There is deliberately **no `at_capacity` row**: the requester's capacity is always overridden, so it
 can never be the reason *they* were skipped.
+
+`already_assigned` was added during implementation, and it plugs a hole this doc had missed: the
+pool's active-assignee filter reads **real** availability, so an away/`auto_assign=false` requester
+does not count as an "active" assignee and their *own* assigned PRs survive into the shared pool —
+where the availability override would then have offered them right back. The service skips any pool
+PR the requester already sits on (mirroring the pool filter, scoped to the requester); it is a
+per-(reviewer, PR) rule like `authored`, not a second pool filter, so Invariant 5 stands.
 
 `outranked` is the non-obvious one and the reason this tally is worth building: without it, an empty
 or short result looks like a bug. It fires on 13.9% of the pairs where a reviewer matched an area,
@@ -621,6 +630,30 @@ re-run with `--size=standard-2x` — `tracemalloc` adds overhead at the moment t
      field alone would measure only half the claims.
   Also verified: the inverted-engine approach agrees with the live engine on all 29,412
   (reviewer, PR) pairs.
+- **2026-08-25 (implementation)** — all five chunks landed, flags dark. Deviations and additions
+  worth knowing about, each argued in place above:
+  1. **Chunks 1 and 2 merged into one commit**: the service reads
+     `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT` / `_MAX_LABELS`, so a separate settings commit would
+     have left a phantom-settings window (the root AGENTS.md antipattern).
+  2. **Chunk order swapped (console before Zulip)**: the Zulip footer reverses
+     `console:suggestions`, so the console URL had to exist first.
+  3. **New `already_assigned` skip reason** — see the note under the skip-tally table. Without it,
+     an away/auto-assign-off reviewer could be suggested a PR they already hold.
+  4. **`format_skip_summary` lives in the service** so the "why not more?" line reads identically
+     in Zulip and on the console (same spirit as `format_load_line`).
+  5. **`unknown_labels` validates against `LabelDef` + the topic pattern**: a requested label is
+     known only when it matches the repo's topic-label pattern *and* exists in the synced label
+     catalog, so typos (`t-algebr`) are reported instead of silently yielding nothing.
+  6. **The console claim re-check runs with an effectively unbounded limit** (verifying
+     *eligibility*, not top-N membership): a still-eligible PR that drifted past rank 10 between
+     render and claim must not be rejected.
+  Validation: service unit tests (`analyzer/tests/services/test_assignment_suggestions.py`,
+  fixture payloads — prefix property, determinism, override/correctness-rule split, per-reason
+  skip tally, honest load line), console view tests (`console/tests/test_suggestions.py` — the
+  claim re-check runs the real service; GitHub mocked), Zulip command tests
+  (`zulip_bot/tests/commands/test_suggest_prs_command.py` — limit, footer, tally, repo scoping).
+  Full app suites (analyzer-services subset, console 78, zulip_bot 343) green against dockerized
+  Postgres; `scripts/repo_check_compose.sh` is the canonical pre-merge run.
 - **2026-08-25 (later)** — measured the one number the baseline had left open: the snapshot payload
   load, via `scripts/probe_053_payload_cost.py`. A request is ~476 ms and the payload read is 83% of
   it; all engine compute together is 85 ms. Two conclusions changed the doc. The cost note no longer

--- a/docs/design-decisions/053-on-demand-assignment-suggestions.md
+++ b/docs/design-decisions/053-on-demand-assignment-suggestions.md
@@ -3,7 +3,8 @@
 > Status: **Implemented** (2026-08-25), feature-flagged and dark: all `ANALYZER_ASSIGNMENT_SUGGESTIONS_*`
 > flags default off, following the 046/050 staged-rollout discipline. See the rollout steps under
 > [Operational Notes](#operational-notes). The design was calibrated against a production
-> measurement taken 2026-08-25 — see [Measured Baseline](#measured-baseline).
+> measurement taken 2026-08-25 and **re-confirmed against production on 2026-08-27**
+> (`engine_mismatches: 0`) — see [Measured Baseline](#measured-baseline).
 
 ## Context
 
@@ -37,6 +38,43 @@ queue snapshot 8 minutes old). Reproduce with `scripts/probe_053_suggestions.py`
 [Reproducing the measurement](#reproducing-the-measurement)). These numbers are what the design
 below is calibrated against; **re-run the probe before enabling the flags** to confirm the shape
 has not changed.
+
+### Re-measured 2026-08-27 (pre-rollout confirmation)
+
+The probe was re-run against production immediately before enabling the flags, as this section
+instructs. **The shape holds and the cost improved.** The 08-25 figures below are left as written —
+they are what the design was calibrated against, and the audit trail is worth more than a tidy
+document. Deltas:
+
+| | 2026-08-25 | 2026-08-27 |
+| --- | --- | --- |
+| `engine_mismatches` (classifier vs live engine) | 0 | **0** |
+| assignable pool | 516 (463 with a topic label) | 519 (463 with a topic label) |
+| placed by the last nightly run | 11 | 14 |
+| median eligible PRs (availability + capacity overridden) | 69 | 70 |
+| reviewers with ≥ 10 eligible | 45 of 57 | 43 of 57 |
+| reviewers with 0 eligible | 3 needing a label override | 4 (2 of them have no stored labels) |
+| end-to-end request | 476 ms median (340–687) | **357 ms** median (333–368) |
+| — payload read share | 411 ms (82.9%) | 276 ms (77.5%) |
+| — all engine compute | 85 ms | 75 ms |
+| payload (compressed / JSON text) | 5.62 / 13.18 MB | 5.51 / 12.90 MB |
+| held payload / transient peak | 28.8 / 81.6 MB | 28.2 / 79.8 MB |
+| peak RSS (whole probe run) | 259 MB | 248 MB |
+| `over_cap_backlog` | (implied 0) | **0**, measured |
+| pool labels with no interested reviewer | none | **none** |
+
+Two integrity checks passed that are worth recording, because they are what make the skip tally
+trustworthy rather than merely plausible:
+
+- `engine_mismatches: 0` — the probe's own skip classifier was cross-checked against the live
+  `suggest_reviewer_for_pr_with_trace` on every (reviewer, PR) pair and never disagreed.
+- The skip tally sums to exactly 29,583 = 57 reviewers × 519 pool PRs in **both** the no-override
+  and the override pass. Every pair is attributed to exactly one reason — no gaps, no double
+  counting.
+
+The counterfactual also re-confirmed, and it is the sharpest number in this document: with no
+overrides — i.e. what the scheduled pipeline can see — **44 of 57 reviewers have zero eligible
+PRs**. With availability and capacity overridden, that falls to 4.
 
 **The candidate pool is large, and the scheduled pipeline places almost none of it.**
 
@@ -185,6 +223,7 @@ class SuggestionResult:
     effective_labels: list[str]      # the override set, else the reviewer's preferred_labels
     label_override: bool
     unknown_labels: list[str]        # requested labels that are not topic labels in this repo
+    dropped_labels: list[str]        # requested labels past MAX_LABELS — reported, never silent
     load: ReviewerLoad | None        # from the reviewer's REAL capacity — never the override
     suggestions: list[SuggestedPR]
     skipped: dict[str, int]          # reason -> count over the assignable pool
@@ -231,10 +270,18 @@ Algorithm:
    then queue age, then `feat:` priority, then PR number. That is the right order *among the PRs a
    given reviewer can take* — the PR that most needs this reviewer comes first. It is worth being
    honest that it is not a per-reviewer ordering: because scarcity-first front-loads PRs that are
-   scarce precisely because few reviewers match them, the median reviewer's first eligible PR sits
-   at rank ~78 of 516. Walking is cheap — 17 ms for the entire pool against a ~476 ms request — so
-   this costs nothing, and the early-stop at `limit` is not an optimisation worth reasoning about:
-   it can save at most 17 ms of a request dominated by the payload read.
+   scarce precisely because few reviewers match them, a reviewer's first eligible PR can sit deep
+   in the ranking. Measured 2026-08-27 under this pass's own semantics (availability and capacity
+   overridden, the reviewer's own labels), the rank of the first eligible PR is median **8**, p75
+   60, p90 **162**, max **302** of 519. Walking is cheap — 16 ms for the entire pool against a
+   ~357 ms request — so this costs nothing, and the early-stop at `limit` is not an optimisation
+   worth reasoning about: it can save at most 16 ms of a request dominated by the payload read.
+
+   **Do not "optimise" this by ranking or walking only a prefix of the pool.** The 16 ms walk is a
+   standing invitation to cap it, and the tail above is why that would be wrong: a top-100 cutoff
+   would return an empty result for the ~10% of reviewers whose first eligible PR ranks past 162,
+   and those are precisely the reviewers with the narrowest areas — the ones this feature exists to
+   reach. The failure would be silent, indistinguishable from "nothing to review right now".
 6. **Walk the ranking**, and for each PR call `suggest_reviewer_for_pr_with_trace` with the override
    catalog. Keep the PR when the normalized requester login appears in `trace["available"]`;
    otherwise record a skip reason. Stop at `limit`. The trace's `picked` field is **ignored** — this
@@ -316,7 +363,7 @@ Carry the request shape in the query string — `?repo=<id>&labels=t-algebra,t-t
 different query. The params are safe on a token-less URL because they pre-fill only repo and labels;
 the login still comes from the session and never from the request (Invariant 6). Validate them
 server-side regardless: `MAX_LABELS` applies to the query string too, and unknown labels already
-have somewhere to go in `unknown_labels`.
+have somewhere to go in `unknown_labels` — labels refused by the cap go to `dropped_labels`.
 
 **Footer wording must stay indefinite** — "more suggestions", never "the next 5" or "5 more like
 these". The prefix property (Invariant 2) holds only within one snapshot generation, and
@@ -507,7 +554,8 @@ Settings (all `settings/base.py` + `.env.example`):
 | `ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED` | off | the console's GitHub write |
 | `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT` | 10 | service default; what the console renders |
 | `ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT` | 5 | surface override for the in-channel reply |
-| `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS` | 5 | cap on the label override set (form and query string alike) |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS` | 5 | cap on the label override set (form and query string alike); labels past it come back in `dropped_labels` |
+| `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS` | 86400 | refuse to answer from a snapshot older than this (0 disables); guards the no-active-rule-set fallback |
 
 `suggest_prs_for_reviewer(limit=None)` falls back to `ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT`, so the
 Zulip setting is a surface override rather than a second parallel knob.
@@ -644,6 +692,17 @@ re-run with `--size=standard-2x` — `tracemalloc` adds overhead at the moment t
   5. **`unknown_labels` validates against `LabelDef` + the topic pattern**: a requested label is
      known only when it matches the repo's topic-label pattern *and* exists in the synced label
      catalog, so typos (`t-algebr`) are reported instead of silently yielding nothing.
+  5b. **`dropped_labels` reports what the `MAX_LABELS` cap refused**, separately from
+     `unknown_labels`. The cap is applied before the known/unknown split, so without a third list
+     those labels land in neither and the request is silently narrowed. That matters more than it
+     looks: reviewers hold up to 11 stored labels against a cap of 5, and the broad label override
+     is the single biggest unlock in the [Measured Baseline](#measured-baseline) — quietly
+     honouring five of eight would make the reviewer's own labels look wrong.
+  5c. **A stale snapshot is refused like a missing one.** When a repo has no *active* rule set the
+     cache key falls back to the literal `"default"`, where a long-dead row can survive (production
+     carries one from 2026-03). Without `MAX_SNAPSHOT_AGE_SECONDS` the no-snapshot guard is
+     satisfied by that row and months-old PRs are served as live — the fabricated answer
+     Invariant 1 exists to prevent, in its quietest possible form.
   6. **The console claim re-check runs with an effectively unbounded limit** (verifying
      *eligibility*, not top-N membership): a still-eligible PR that drifted past rank 10 between
      render and claim must not be rejected.

--- a/docs/sandboxed_docker_setup.md
+++ b/docs/sandboxed_docker_setup.md
@@ -1,0 +1,154 @@
+# Running Docker checks from a sandboxed environment
+
+Why `DOCKER_CONFIG` and `DOCKER_HOST` may be set for a sandboxed shell on this machine, and how to
+rebuild or undo that setup. If you are reading this because you found those variables in a sandbox
+config and cannot remember why: [the short version](#the-short-version).
+
+Only needed when a **sandbox wraps the shell** (e.g. an agent harness restricting filesystem
+writes). A normal terminal needs none of this — `bash scripts/repo_check_compose.sh` just works.
+
+## The short version
+
+Docker Desktop's credential helper crashes when it cannot write to `~/Library/Containers/`, which
+takes down every image pull — even though this project pulls only public images and needs no
+credentials at all. Pointing `DOCKER_CONFIG` at a config that omits `credsStore` skips the helper
+entirely. `DOCKER_HOST` is required because overriding `DOCKER_CONFIG` also moves where the CLI
+looks for its *contexts*.
+
+Verified 2026-08-27: with this in place, `scripts/repo_check_compose.sh` completes all 12 steps
+inside the sandbox, image build included.
+
+## Symptom
+
+```
+failed to solve: error getting credentials - err: exit status 1, out: ``
+```
+
+preceded by a `docker-credential-desktop` stack trace:
+
+```
+[docker-credential-desktop.paths][F] creating <HOME>/Library/Containers/com.docker.docker/Data:
+    mkdir <HOME>/Library/Containers: file exists
+```
+
+## Diagnosis in one command
+
+```bash
+echo '{"ServerURL":"https://index.docker.io/v1/"}' | docker-credential-desktop get
+```
+
+A `[F] creating <HOME>/Library/Containers/...` line means the helper is the problem. Anything else
+— including "credentials not found" — means it is healthy and your build is failing for some other
+reason. Use this before changing anything, and again to confirm a fix.
+
+## Root cause
+
+`docker-credential-desktop` calls `MkdirAll` on `~/Library/Containers/com.docker.docker/Data`
+during startup. Under the sandbox every `stat` up that chain is denied, so it walks to the top and
+tries `mkdir ~/Library/Containers`, gets `EEXIST`, and cannot `stat` to confirm it is a directory —
+which it treats as fatal. It dies before doing any credential work, and BuildKit reports the
+generic "error getting credentials".
+
+The helper runs only because `~/.docker/config.json` sets `"credsStore": "desktop"`. Every image
+this stack pulls is public — `python:3.12-slim`, `postgres:16-alpine`, `redis:7-alpine` — so
+nothing here needs a credential helper.
+
+**Read-only access to those paths does not help.** The failure is a write.
+
+## Setup
+
+Everything lives in the repo and is gitignored, so this works from inside the sandbox and needs no
+host step:
+
+```bash
+mkdir -p .docker-nocreds
+printf '{"auths":{}}\n' > .docker-nocreds/config.json
+ln -sfn /Applications/Docker.app/Contents/Resources/cli-plugins .docker-nocreds/cli-plugins
+
+cat > .docker-env <<EOF
+DOCKER_CONFIG=$(pwd)/.docker-nocreds
+DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
+EOF
+```
+
+`.docker-env.example` in the repo root carries the same thing with the commentary.
+
+**Why in the repo and not `~/.docker-nocreds`?** Because a new directory under `$HOME` is not
+readable from the sandbox. This is worth knowing because the failure is easy to misread: the
+sandbox returns `ENOENT` for home paths that do not exist, but `EPERM`
+(`Operation not permitted`) for ones that exist outside its allowlist — so a `~/.docker-nocreds`
+you just created looks identical to a permissions bug. The repo directory is both readable and
+writable, which also means the setup can be recreated without leaving the sandbox.
+
+The symlink points at Docker Desktop's own plugin directory, so this never references `~/.docker`
+at all — see [Does this affect my other Docker projects?](#does-this-affect-my-other-docker-projects).
+(`~/.docker/cli-plugins` works equally well; its entries are themselves symlinks into that same
+bundle. Pointing at the bundle keeps the two configurations visibly independent.)
+
+Docker only ever **reads** this directory, so it can be read-only (`chmod 555`) if you prefer —
+verified. Note the contrast with `~/Library/Containers/com.docker.docker/`, where read-only is
+*not* enough, because there the helper is trying to create directories.
+
+## Passing it to the sandbox
+
+Point your sandbox wrapper's env-file option at `.docker-env`, or source it:
+
+```bash
+set -a; . ./.docker-env; set +a
+```
+
+Use **absolute paths** — a `~` will not be expanded by Docker or, in most cases, by the wrapper.
+The generator above writes absolute paths for you.
+
+## Does this affect my other Docker projects?
+
+No. Nothing here writes to, modifies, or is read from `~/.docker`.
+
+- **The symlink goes the other way than it may read.** `ln -s TARGET LINK` creates `LINK`, so the
+  new symlink lives *inside* `~/.docker-nocreds/` and points outward at a directory Docker Desktop
+  owns. No file is created or changed anywhere else.
+- **Other projects never see any of this.** `DOCKER_CONFIG` is set only for the sandboxed process.
+  Any other shell falls back to `~/.docker/config.json`, `credsStore: "desktop"` included, and
+  keeps using the credential helper normally — including for private registries.
+- **The undo is safe.** `rm -rf ~/.docker-nocreds` removes the symlink itself, not what it points
+  at; `rm -rf` does not follow symlinks. Verified explicitly, because getting this wrong would
+  delete your Docker CLI plugins.
+- **The only shared thing is the daemon socket** (`DOCKER_HOST`), which is the same socket every
+  Docker client on the machine already talks to. Containers, images and volumes are unaffected.
+
+The one real trade-off is the one in [When this stops working](#when-this-stops-working): inside
+the sandbox you have no credential helper, so a private-registry image would fail there. Outside
+the sandbox, nothing changes.
+
+## Verify
+
+Run these **inside the sandbox** — that is the environment the problem appears in:
+
+```bash
+echo '{"ServerURL":"https://index.docker.io/v1/"}' | docker-credential-desktop get   # no [F] line
+bash scripts/repo_check_compose.sh                                                   # exit 0, [0/12]..[12/12]
+```
+
+Run the script **unpiped** — `… | tail` reports `tail`'s status, not the script's, so a failure
+reads as success. See the Testing Guidelines in the root `AGENTS.md`.
+
+## When this stops working
+
+This trades away credential support, which is free *only* while every image is public. **If a
+private-registry image is ever added to `docker-compose.yml` or `Dockerfile`, this setup breaks**
+with an authentication error on that image. At that point you need the real helper, which means
+granting the sandbox **write** access to `~/Library/Containers/com.docker.docker/` and dropping
+these two variables.
+
+That is also the alternative if you would rather not maintain this at all: open that path, keep
+Docker's normal credential flow, and delete `~/.docker-nocreds`.
+
+## Undo
+
+```bash
+rm -rf .docker-nocreds .docker-env
+```
+
+and stop passing the env file to the sandbox. Nothing outside the repo was ever changed — `rm -rf`
+removes the symlink, not Docker Desktop's plugin directory that it points at (verified, since
+getting that wrong would delete your Docker CLI plugins).

--- a/qb_site/AGENTS.md
+++ b/qb_site/AGENTS.md
@@ -85,8 +85,11 @@ uv run python qb_site/manage.py test zulip_bot
     python qb_site/manage.py test <app>                      # cached image, no rebuild
   ```
   Both the `cli-plugins` symlink and `DOCKER_HOST` are required: overriding `DOCKER_CONFIG` moves
-  where the CLI looks for plugins *and* for contexts. Ask the user to run the canonical script
-  outside the sandbox for a real end-to-end check, and say which steps you covered.
+  where the CLI looks for plugins *and* for contexts. With that env in place the **canonical
+  script itself runs green in the sandbox** — `bash scripts/repo_check_compose.sh` completes all
+  12 steps including the image build, so prefer running it over assembling the steps by hand.
+  This holds only while every image is public; a private-registry image would need the credential
+  helper, and therefore write access to `~/Library/Containers/com.docker.docker/`.
 - If Docker/Compose is unavailable:
   - run non-DB checks (`ruff`, GraphQL validation, pure-Python tests where applicable),
   - run targeted tests that do not require the DB,

--- a/qb_site/AGENTS.md
+++ b/qb_site/AGENTS.md
@@ -76,6 +76,27 @@ uv run python qb_site/manage.py test zulip_bot
   - or ask the user to run `scripts/repo_check_compose.sh` and share results.
 - When reporting verification, explicitly state what was and was not runnable.
 
+## Test Isolation: Shared Redis
+
+`syncer.services.task_dedupe` and `syncer.services.rate_budget` write short-TTL keys to the
+Celery broker's Redis. Dedupe keys are `(repo_id, pr_number)`-scoped and the test database is
+recreated on every run, so ids restart from 1 and a run collides with the *previous* run's
+leftovers — `sync_pr` returns `runtime_deduped` / `recently_processed` and any test expecting real
+work fails.
+
+Two guards, both in place:
+- `TEST_RUNNER` (`qb_site.test_runner.IsolatedRedisDiscoverRunner`, set in `base.py`) clears the
+  app's Redis namespaces before the suite starts. Scan-and-delete over the prefixes in
+  `SHARED_REDIS_KEY_PATTERNS`, never `FLUSHDB`.
+- `ci.py` repoints the broker at its own Redis database index (`CI_REDIS_DB_INDEX`, default 15) so
+  a test run cannot write into the keyspace a `docker compose up` dev stack is using.
+
+**If you add a Redis key prefix to those modules, add a matching entry to
+`SHARED_REDIS_KEY_PATTERNS`.** `syncer/tests/test_redis_isolation.py` scans both modules for key
+literals and fails if one is not covered. Symptoms of the leak returning are misleading — failures
+land in unrelated suites (backfill), only after several consecutive runs, and each failing test
+passes in isolation — so trust the guard test over the appearance of flakiness.
+
 ## Concurrent Writers and Unique Keys
 Celery workers overlap: per-PR tasks (`syncer.sync_pr`, `analyzer.process_pr`), periodic
 sweeps, admin actions, and management commands can all write the same rows at the same

--- a/qb_site/AGENTS.md
+++ b/qb_site/AGENTS.md
@@ -70,6 +70,23 @@ uv run python qb_site/manage.py test zulip_bot
     Compose, which loads `.env` via `env_file`).
   - This is for quick iteration only; `scripts/repo_check_compose.sh` stays canonical
     (it also runs migrations via the `migrate` service and backup-policy validation).
+- If a build fails with `failed to solve: error getting credentials` and a
+  `docker-credential-desktop` crash trying to `mkdir` under `~/Library/Containers/`, that is a
+  sandboxed environment blocking the credential helper's writes — not a Docker or repo problem.
+  Every image this stack pulls is public (`python:3.12-slim`, `postgres:16-alpine`,
+  `redis:7-alpine`), so the helper is not needed at all; it runs only because `~/.docker/config.json`
+  sets `credsStore: "desktop"`. Reuse the already-built images and give Docker a config without it:
+  ```bash
+  export DOCKER_CONFIG="$SCRATCH/dockercfg"                  # containing just {"auths":{}}
+  ln -sfn ~/.docker/cli-plugins "$DOCKER_CONFIG/cli-plugins" # else `docker compose` vanishes
+  export DOCKER_HOST="unix://$HOME/.docker/run/docker.sock"  # else the desktop context is lost
+  docker compose up -d db redis
+  docker compose run --rm --no-deps -T web env DJANGO_SETTINGS_MODULE=qb_site.settings.ci \
+    python qb_site/manage.py test <app>                      # cached image, no rebuild
+  ```
+  Both the `cli-plugins` symlink and `DOCKER_HOST` are required: overriding `DOCKER_CONFIG` moves
+  where the CLI looks for plugins *and* for contexts. Ask the user to run the canonical script
+  outside the sandbox for a real end-to-end check, and say which steps you covered.
 - If Docker/Compose is unavailable:
   - run non-DB checks (`ruff`, GraphQL validation, pure-Python tests where applicable),
   - run targeted tests that do not require the DB,

--- a/qb_site/AGENTS.md
+++ b/qb_site/AGENTS.md
@@ -70,26 +70,12 @@ uv run python qb_site/manage.py test zulip_bot
     Compose, which loads `.env` via `env_file`).
   - This is for quick iteration only; `scripts/repo_check_compose.sh` stays canonical
     (it also runs migrations via the `migrate` service and backup-policy validation).
-- If a build fails with `failed to solve: error getting credentials` and a
-  `docker-credential-desktop` crash trying to `mkdir` under `~/Library/Containers/`, that is a
-  sandboxed environment blocking the credential helper's writes — not a Docker or repo problem.
-  Every image this stack pulls is public (`python:3.12-slim`, `postgres:16-alpine`,
-  `redis:7-alpine`), so the helper is not needed at all; it runs only because `~/.docker/config.json`
-  sets `credsStore: "desktop"`. Reuse the already-built images and give Docker a config without it:
-  ```bash
-  export DOCKER_CONFIG="$SCRATCH/dockercfg"                  # containing just {"auths":{}}
-  ln -sfn ~/.docker/cli-plugins "$DOCKER_CONFIG/cli-plugins" # else `docker compose` vanishes
-  export DOCKER_HOST="unix://$HOME/.docker/run/docker.sock"  # else the desktop context is lost
-  docker compose up -d db redis
-  docker compose run --rm --no-deps -T web env DJANGO_SETTINGS_MODULE=qb_site.settings.ci \
-    python qb_site/manage.py test <app>                      # cached image, no rebuild
-  ```
-  Both the `cli-plugins` symlink and `DOCKER_HOST` are required: overriding `DOCKER_CONFIG` moves
-  where the CLI looks for plugins *and* for contexts. With that env in place the **canonical
-  script itself runs green in the sandbox** — `bash scripts/repo_check_compose.sh` completes all
-  12 steps including the image build, so prefer running it over assembling the steps by hand.
-  This holds only while every image is public; a private-registry image would need the credential
-  helper, and therefore write access to `~/Library/Containers/com.docker.docker/`.
+- If a build fails with `failed to solve: error getting credentials`, preceded by a
+  `docker-credential-desktop` stack trace about `mkdir <HOME>/Library/Containers`, that is a
+  sandboxed environment blocking the credential helper's writes — not a Docker or repo problem, and
+  not something to work around by hand. See **`docs/sandboxed_docker_setup.md`**: one-command
+  diagnosis, the two env vars that fix it, and why read-only access does not. With that setup the
+  canonical script runs green in the sandbox, all 12 steps including the image build.
 - If Docker/Compose is unavailable:
   - run non-DB checks (`ruff`, GraphQL validation, pure-Python tests where applicable),
   - run targeted tests that do not require the DB,

--- a/qb_site/analyzer/AGENTS.md
+++ b/qb_site/analyzer/AGENTS.md
@@ -29,6 +29,10 @@
     unmodified and correctness rules (authorship, conflicts, opt-outs, cooldowns) stay in force —
     and reads only the trace's `available`/`potential` membership, never the random `picked`, so
     results are deterministic per snapshot. Read-only: never builds a snapshot, persists nothing.
+    Refuses a snapshot older than `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS`
+    (0 disables) so the no-active-rule-set `cache_key="default"` fallback cannot serve a long-dead
+    row as live. Label overrides report back both `unknown_labels` (not topic labels here) and
+    `dropped_labels` (refused by the `MAX_LABELS` cap) — neither is ever silently discarded.
     Also exports `format_skip_summary` (the shared "why not more?" line) and the STATUS_*/SKIP_*
     constants.
   - `pr_info.py` — `get_pr_queue_info(owner, repo, pr_number)`: returns `PRQueueInfo` for a single PR; prefers the default `QueueSnapshot`, falls back to direct DB queries for merged/closed PRs. Also exposes the acceptance-gate `proposed_to`/`proposal_expires_at` (design doc 050), read live from the single active `AssignmentProposal`, distinct from `assignee_logins`.

--- a/qb_site/analyzer/AGENTS.md
+++ b/qb_site/analyzer/AGENTS.md
@@ -19,6 +19,18 @@
     per design doc 050) as of the latest cached queue snapshot, plus `format_load_line`. Single authority shared by
     the `assigned-prs` command, the daily reviewer-attention digest, and the reviewer console; read-only (never
     builds a snapshot), returns `{}`/`None` when no snapshot exists.
+  - `assignment_suggestions.py` — `suggest_prs_for_reviewer(repository, login, *, labels, limit)`:
+    on-demand "what should I review?" (design doc 053). Single authority for which open PRs a
+    reviewer could take right now and why not the rest; the Zulip `suggest-prs` command and the
+    console suggestions page both render its output and never re-derive eligibility. Shares the
+    nightly builder's candidate pool via `reviewer_assignment.prepare_assignment_inputs` (new pool
+    exclusions belong there, not at call sites), overrides only the requester's push throttles
+    (`away_until`, `auto_assign`, `maximum_capacity`) via a profile substitution — the engine is
+    unmodified and correctness rules (authorship, conflicts, opt-outs, cooldowns) stay in force —
+    and reads only the trace's `available`/`potential` membership, never the random `picked`, so
+    results are deterministic per snapshot. Read-only: never builds a snapshot, persists nothing.
+    Also exports `format_skip_summary` (the shared "why not more?" line) and the STATUS_*/SKIP_*
+    constants.
   - `pr_info.py` — `get_pr_queue_info(owner, repo, pr_number)`: returns `PRQueueInfo` for a single PR; prefers the default `QueueSnapshot`, falls back to direct DB queries for merged/closed PRs. Also exposes the acceptance-gate `proposed_to`/`proposal_expires_at` (design doc 050), read live from the single active `AssignmentProposal`, distinct from `assignee_logins`.
   - `ci_evaluation.py` — single-PR CI status evaluation against a ruleset's `required_ci_contexts`; use `ci_status_for_pr(pr, rules, repository)` instead of re-implementing context-matching logic.
 

--- a/qb_site/analyzer/services/assignment_suggestions.py
+++ b/qb_site/analyzer/services/assignment_suggestions.py
@@ -71,6 +71,31 @@ SKIP_OUTRANKED = "outranked"
 SKIP_EXCLUDED = "excluded"
 
 
+# Human phrasing for the skip tally, in the engine's evaluation order (also the render order).
+# Shared by both surfaces so "why not more?" reads the same in Zulip and on the console.
+_SKIP_PHRASES: dict[str, str] = {
+    SKIP_ALREADY_ASSIGNED: "already assigned to you",
+    SKIP_NO_TOPIC_LABEL: "with no topic label",
+    SKIP_AUTHORED: "authored by you",
+    SKIP_CONFLICT_OF_INTEREST: "conflict of interest",
+    SKIP_NO_AREA_MATCH: "not matching your labels",
+    SKIP_OUTRANKED: "outranked (another reviewer matches more of the PR's labels)",
+    SKIP_EXCLUDED: "opted out or on cooldown",
+}
+_SKIP_ORDER: tuple[str, ...] = tuple(_SKIP_PHRASES)
+
+
+def format_skip_summary(skipped: dict[str, int]) -> str:
+    """One-line human rendering of the skip tally, e.g. ``312 not matching your labels, 7 outranked (…)``.
+
+    Returns ``""`` for an empty tally. This is what makes an empty or short result legible instead
+    of looking like a bug — ``outranked`` especially (see the design doc's Measured Baseline).
+    """
+    parts = [f"{skipped[reason]} {_SKIP_PHRASES[reason]}" for reason in _SKIP_ORDER if skipped.get(reason)]
+    parts.extend(f"{count} {reason}" for reason, count in skipped.items() if reason not in _SKIP_PHRASES and count)
+    return ", ".join(parts)
+
+
 @dataclass(frozen=True)
 class SuggestedPR:
     pr_number: int
@@ -346,5 +371,6 @@ __all__ = [
     "STATUS_OK",
     "SuggestedPR",
     "SuggestionResult",
+    "format_skip_summary",
     "suggest_prs_for_reviewer",
 ]

--- a/qb_site/analyzer/services/assignment_suggestions.py
+++ b/qb_site/analyzer/services/assignment_suggestions.py
@@ -42,6 +42,7 @@ from analyzer.services.reviewer_assignment import _compute_weight, prepare_assig
 from analyzer.services.reviewer_assignment_engine import (
     ReviewerProfile,
     _normalize_login,
+    _reviewer_candidate_state,
     _topic_labels,
     rank_prs_for_assignment,
     suggest_reviewer_for_pr_with_trace,
@@ -105,7 +106,7 @@ class SuggestedPR:
     topic_labels: list[str]
     matched_labels: list[str]  # intersection with the effective label set
     queue_age_seconds: float | None
-    available_reviewer_count: int  # scarcity, from the ranking scorer's `details`
+    available_reviewer_count: int  # scarcity, against the REAL catalog (never the override)
     load_weight: float  # what claiming it would add to the reviewer's load
 
 
@@ -116,6 +117,7 @@ class SuggestionResult:
     effective_labels: list[str]  # the override set, else the reviewer's preferred_labels
     label_override: bool
     unknown_labels: list[str]  # requested labels that are not topic labels in this repo
+    dropped_labels: list[str]  # requested labels past MAX_LABELS — used by neither, reported to both
     load: ReviewerLoad | None  # from the reviewer's REAL capacity — never the override
     suggestions: list[SuggestedPR]
     skipped: dict[str, int]  # reason -> count over the assignable pool
@@ -128,16 +130,18 @@ def _resolve_label_override(
     labels: Sequence[str] | None,
     *,
     matcher: TopicLabelMatcher,
-) -> tuple[list[str], list[str]]:
-    """Split the requested override labels into normalized ``(known, unknown)`` lists.
+) -> tuple[list[str], list[str], list[str]]:
+    """Split the requested override labels into normalized ``(known, unknown, dropped)`` lists.
 
-    Normalizes (strip + lowercase), dedupes preserving request order, and caps the set at
-    ``ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS`` (labels beyond the cap are dropped; the caller
-    can compare its request against ``effective_labels`` to see what was used). A label is
-    *known* when it matches the repo's topic-label pattern AND exists in the repo's synced label
-    catalog (``LabelDef``) — so typos and non-topic labels are reported back via
-    ``unknown_labels`` instead of silently yielding nothing. ``(labels or [])`` with no usable
-    tokens means "no override".
+    Normalizes (strip + lowercase) and dedupes preserving request order. A label is *known* when
+    it matches the repo's topic-label pattern AND exists in the repo's synced label catalog
+    (``LabelDef``) — so typos and non-topic labels come back in ``unknown`` instead of silently
+    yielding nothing. ``(labels or [])`` with no usable tokens means "no override".
+
+    Labels past ``ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS`` come back in ``dropped``. The cap
+    is applied *before* the known/unknown split, so without this third list they would land in
+    neither and the request would be silently narrowed — the broad label override is the feature's
+    biggest unlock, which makes quietly honouring five of eight labels the worst place to be quiet.
     """
     requested: list[str] = []
     seen: set[str] = set()
@@ -148,9 +152,9 @@ def _resolve_label_override(
         seen.add(norm)
         requested.append(norm)
     if not requested:
-        return [], []
+        return [], [], []
     max_labels = int(settings.ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS)
-    requested = requested[:max_labels]
+    requested, dropped = requested[:max_labels], requested[max_labels:]
     catalog_lower = set(
         LabelDef.objects.filter(repository=repository)
         .annotate(name_lower=Lower("name"))
@@ -160,7 +164,7 @@ def _resolve_label_override(
     known = [lab for lab in requested if matcher(lab) and lab in catalog_lower]
     known_set = set(known)
     unknown = [lab for lab in requested if lab not in known_set]
-    return known, unknown
+    return known, unknown, dropped
 
 
 def _classify_skip(
@@ -225,6 +229,7 @@ def suggest_prs_for_reviewer(
             effective_labels=[],
             label_override=False,
             unknown_labels=[],
+            dropped_labels=[],
             load=None,
             suggestions=[],
             skipped={},
@@ -242,6 +247,14 @@ def suggest_prs_for_reviewer(
         return _result(status=STATUS_NO_SNAPSHOT)
     payload = snapshot.payload
     generated_at = snapshot.generated_at
+    # A stale snapshot is no better than a missing one and fails far more quietly. When a repo has
+    # no *active* rule set, `cache_key` falls back to the literal "default" — where a long-dead row
+    # can still be sitting (production carries one generated five months ago). Without a ceiling the
+    # guard above is satisfied by that row and the feature serves months-old PRs as though live,
+    # which is exactly the fabricated answer Invariant 1 exists to prevent. `<= 0` disables it.
+    max_age_seconds = int(settings.ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS)
+    if max_age_seconds > 0 and (current_time - generated_at).total_seconds() > max_age_seconds:
+        return _result(status=STATUS_NO_SNAPSHOT, snapshot_generated_at=generated_at)
 
     # One candidate pool, shared with the nightly builder by construction (Invariant 5).
     inputs = prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=rule_set)
@@ -250,8 +263,8 @@ def suggest_prs_for_reviewer(
         return _result(status=STATUS_NOT_A_REVIEWER, snapshot_generated_at=generated_at)
 
     matcher = topic_label_matcher_for_repo(repository)
-    known_labels, unknown_labels = _resolve_label_override(repository, labels, matcher=matcher)
-    label_override = bool(known_labels or unknown_labels)
+    known_labels, unknown_labels, dropped_labels = _resolve_label_override(repository, labels, matcher=matcher)
+    label_override = bool(known_labels or unknown_labels or dropped_labels)
 
     # The request profile: an explicit request overrides the push throttles (Invariant 4). The
     # capacity override is unconditional (Invariant 7) — the load line below carries the honest
@@ -272,6 +285,7 @@ def suggest_prs_for_reviewer(
         effective_labels=effective_labels,
         label_override=label_override,
         unknown_labels=unknown_labels,
+        dropped_labels=dropped_labels,
         load=load,
         snapshot_generated_at=generated_at,
     )
@@ -334,6 +348,20 @@ def suggest_prs_for_reviewer(
         details = (ranking_trace.get(str(pr_number)) or {}).get("details") or {}
         topic_labels = _topic_labels(pr_entry, matcher)
         queue_age = details.get("queue_age_seconds")
+        # Scarcity is recomputed against the REAL catalog rather than read from the ranking's
+        # `details`. The ranking necessarily runs over the override catalog, where the requester
+        # is unconditionally available — so `details["available_reviewer_count"]` counts them even
+        # when they are really at capacity or away, overstating supply by one to exactly the
+        # reviewer reading the number, and most where it matters (a "1 available reviewer" PR is
+        # really 0). The ranking itself is deliberately left on the override catalog; only this
+        # displayed count is honest. Bounded by `limit`, so at most `limit` extra evaluations.
+        _, real_available, _, _ = _reviewer_candidate_state(
+            pr_entry=pr_entry,
+            reviewers=inputs.reviewers,
+            assignment_stats=inputs.assignments,
+            excluded_logins=inputs.excluded_by_pr.get(pr_number),
+            topic_label_matcher=matcher,
+        )
         suggestions.append(
             SuggestedPR(
                 pr_number=int(pr_number),
@@ -343,7 +371,7 @@ def suggest_prs_for_reviewer(
                 topic_labels=topic_labels,
                 matched_labels=[lab for lab in topic_labels if lab.lower() in requester.preferred_labels_lower],
                 queue_age_seconds=float(queue_age) if queue_age is not None else None,
-                available_reviewer_count=int(details.get("available_reviewer_count") or 0),
+                available_reviewer_count=len(real_available),
                 load_weight=_compute_weight(int(pr_number), pr_entry),
             )
         )

--- a/qb_site/analyzer/services/assignment_suggestions.py
+++ b/qb_site/analyzer/services/assignment_suggestions.py
@@ -1,0 +1,350 @@
+"""On-demand assignment suggestions — "what should I review?" (design doc 053).
+
+Single authority for "which open PRs could this reviewer take right now, and why not the rest".
+Both reviewer-facing surfaces (the ``suggest-prs`` Zulip command and the console suggestions page)
+render this module's output; neither re-derives eligibility.
+
+The inversion of the nightly *PR → reviewer* engine is one seam, not an engine change: the
+requester's ``ReviewerProfile`` is replaced in the shared candidate catalog with an override copy
+(availability and capacity forced open, optionally the label set replaced), and every downstream
+engine call then sees the override. Key invariants (numbered as in the design doc):
+
+1. Read-only and stateless: a suggestion is a pure function of (snapshot payload, live
+   preference/proposal/opt-out state), computed and discarded. Never builds a snapshot.
+2. Reproducible: only the trace's ``available`` membership is read — never the engine's weighted
+   random ``picked`` — and the ranking's sort key is a total order, so identical requests against
+   one snapshot generation return identical ordered results (and a smaller ``limit`` returns a
+   strict prefix of a larger one).
+4. Push-throttle preferences (``away_until``, ``auto_assign``, ``maximum_capacity``) are
+   overridden by the explicit request; correctness rules (authorship, conflict-of-interest,
+   opt-outs, cooldowns, assignment-forbidden labels, active assignees/proposals) never are.
+5. One candidate pool: the assignable set comes from ``prepare_assignment_inputs``, shared with
+   the nightly builder, so a suggestion can never offer what the scheduled run would refuse.
+7. Capacity is reported, never enforced: ``load`` comes from the reviewer's *real*
+   ``ReviewerPreference.maximum_capacity`` (via ``reviewer_load_for``), not the override, so the
+   rendered load line stays the honest capacity signal.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Sequence
+
+from django.conf import settings
+from django.db.models.functions import Lower
+
+from analyzer.models import QueueSnapshot
+from analyzer.services.queue_rules import default_rule_set_for_repo
+from analyzer.services.reviewer_assignment import _compute_weight, prepare_assignment_inputs
+from analyzer.services.reviewer_assignment_engine import (
+    ReviewerProfile,
+    _normalize_login,
+    _topic_labels,
+    rank_prs_for_assignment,
+    suggest_reviewer_for_pr_with_trace,
+)
+from analyzer.services.reviewer_load import ReviewerLoad, reviewer_load_for
+from core.models import Repository
+from core.services.topic_labels import TopicLabelMatcher, topic_label_matcher_for_repo
+from syncer.models import LabelDef
+
+# Result statuses. Only STATUS_OK carries suggestions; the others explain why there are none,
+# so surfaces never have to guess whether an empty list means "nothing" or "could not answer".
+STATUS_OK = "ok"
+STATUS_NO_SNAPSHOT = "no_snapshot"
+STATUS_NOT_A_REVIEWER = "not_a_reviewer"
+STATUS_NO_LABELS = "no_labels"
+STATUS_NONE_ELIGIBLE = "none_eligible"
+
+# Skip-tally reasons, in the engine's own evaluation order (each pool PR is counted once against
+# the first rule that excluded the requester). Deliberately no `at_capacity`: the requester's
+# capacity is always overridden, so it can never be the reason *they* were skipped (Invariant 7).
+SKIP_ALREADY_ASSIGNED = "already_assigned"
+SKIP_NO_TOPIC_LABEL = "no_topic_label"
+SKIP_AUTHORED = "authored"
+SKIP_CONFLICT_OF_INTEREST = "conflict_of_interest"
+SKIP_NO_AREA_MATCH = "no_area_match"
+SKIP_OUTRANKED = "outranked"
+SKIP_EXCLUDED = "excluded"
+
+
+@dataclass(frozen=True)
+class SuggestedPR:
+    pr_number: int
+    title: str
+    url: str
+    author_login: str
+    topic_labels: list[str]
+    matched_labels: list[str]  # intersection with the effective label set
+    queue_age_seconds: float | None
+    available_reviewer_count: int  # scarcity, from the ranking scorer's `details`
+    load_weight: float  # what claiming it would add to the reviewer's load
+
+
+@dataclass(frozen=True)
+class SuggestionResult:
+    repository_id: int
+    reviewer_login: str  # normalized
+    effective_labels: list[str]  # the override set, else the reviewer's preferred_labels
+    label_override: bool
+    unknown_labels: list[str]  # requested labels that are not topic labels in this repo
+    load: ReviewerLoad | None  # from the reviewer's REAL capacity — never the override
+    suggestions: list[SuggestedPR]
+    skipped: dict[str, int]  # reason -> count over the assignable pool
+    snapshot_generated_at: datetime | None
+    status: str  # ok | no_snapshot | not_a_reviewer | no_labels | none_eligible
+
+
+def _resolve_label_override(
+    repository: Repository,
+    labels: Sequence[str] | None,
+    *,
+    matcher: TopicLabelMatcher,
+) -> tuple[list[str], list[str]]:
+    """Split the requested override labels into normalized ``(known, unknown)`` lists.
+
+    Normalizes (strip + lowercase), dedupes preserving request order, and caps the set at
+    ``ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS`` (labels beyond the cap are dropped; the caller
+    can compare its request against ``effective_labels`` to see what was used). A label is
+    *known* when it matches the repo's topic-label pattern AND exists in the repo's synced label
+    catalog (``LabelDef``) — so typos and non-topic labels are reported back via
+    ``unknown_labels`` instead of silently yielding nothing. ``(labels or [])`` with no usable
+    tokens means "no override".
+    """
+    requested: list[str] = []
+    seen: set[str] = set()
+    for raw in labels or []:
+        norm = str(raw or "").strip().lower()
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        requested.append(norm)
+    if not requested:
+        return [], []
+    max_labels = int(settings.ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS)
+    requested = requested[:max_labels]
+    catalog_lower = set(
+        LabelDef.objects.filter(repository=repository)
+        .annotate(name_lower=Lower("name"))
+        .filter(name_lower__in=requested)
+        .values_list("name_lower", flat=True)
+    )
+    known = [lab for lab in requested if matcher(lab) and lab in catalog_lower]
+    known_set = set(known)
+    unknown = [lab for lab in requested if lab not in known_set]
+    return known, unknown
+
+
+def _classify_skip(
+    *,
+    pr_entry: dict,
+    requester: ReviewerProfile,
+    requester_norm: str,
+    trace: dict,
+    matcher: TopicLabelMatcher,
+) -> str:
+    """Attribute one skipped (requester, PR) pair to the first engine rule that excluded them.
+
+    Reads the trace's ``potential`` membership (max_score survivors) plus a little local
+    classification; the checks mirror ``_reviewer_candidate_state`` in its evaluation order so
+    each pair lands on exactly one reason.
+    """
+    topic_lower = {lab.lower() for lab in _topic_labels(pr_entry, matcher)}
+    if not topic_lower:
+        return SKIP_NO_TOPIC_LABEL
+    author_norm = _normalize_login(pr_entry.get("author"))
+    if author_norm == requester_norm:
+        return SKIP_AUTHORED
+    if author_norm in requester.conflict_of_interest_lower:
+        return SKIP_CONFLICT_OF_INTEREST
+    if not (topic_lower & requester.preferred_labels_lower):
+        return SKIP_NO_AREA_MATCH
+    potential_norm = {_normalize_login(login) for login in trace.get("potential", [])}
+    if requester_norm not in potential_norm:
+        # Matched an area but was dropped by the engine's max_score contest: another reviewer
+        # matched more of this PR's labels. The non-obvious reason an eligible-looking PR is
+        # missing — see the design doc's Measured Baseline.
+        return SKIP_OUTRANKED
+    # In `potential` but not `available` with availability + capacity overridden: the only
+    # remaining filter is the per-PR exclusion set (opt-out / expired-proposal cooldown).
+    return SKIP_EXCLUDED
+
+
+def suggest_prs_for_reviewer(
+    repository: Repository,
+    reviewer_login: str,
+    *,
+    labels: Sequence[str] | None = None,
+    limit: int | None = None,  # None -> ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT
+    now: datetime | None = None,
+) -> SuggestionResult:
+    """Open PRs the reviewer could take right now, ranked as the nightly builder would rank them.
+
+    Read-only (Invariant 1): reads the cached queue snapshot for the repo's default rule set —
+    never builds one — and persists nothing. ``labels`` *replaces* the reviewer's stored
+    ``preferred_labels`` for this request; the request also overrides ``away_until``,
+    ``auto_assign`` and ``maximum_capacity`` (push throttles, Invariant 4), while authorship,
+    conflict-of-interest, opt-outs, cooldowns and the pool filters stay in force.
+    """
+    current_time = now or datetime.now(timezone.utc)
+    effective_limit = int(settings.ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT) if limit is None else int(limit)
+    requester_norm = _normalize_login(reviewer_login)
+
+    def _result(**overrides) -> SuggestionResult:
+        base = dict(
+            repository_id=int(repository.id),
+            reviewer_login=requester_norm,
+            effective_labels=[],
+            label_override=False,
+            unknown_labels=[],
+            load=None,
+            suggestions=[],
+            skipped={},
+            snapshot_generated_at=None,
+            status=STATUS_OK,
+        )
+        base.update(overrides)
+        return SuggestionResult(**base)
+
+    rule_set = default_rule_set_for_repo(repository)
+    cache_key = str(rule_set.id) if rule_set else "default"
+    snapshot = QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key).order_by("-generated_at").first()
+    if snapshot is None or not snapshot.payload:
+        # No snapshot means no answer — never a fabricated empty list.
+        return _result(status=STATUS_NO_SNAPSHOT)
+    payload = snapshot.payload
+    generated_at = snapshot.generated_at
+
+    # One candidate pool, shared with the nightly builder by construction (Invariant 5).
+    inputs = prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=rule_set)
+    profile = next((r for r in inputs.reviewers if _normalize_login(r.github_login) == requester_norm), None)
+    if profile is None:
+        return _result(status=STATUS_NOT_A_REVIEWER, snapshot_generated_at=generated_at)
+
+    matcher = topic_label_matcher_for_repo(repository)
+    known_labels, unknown_labels = _resolve_label_override(repository, labels, matcher=matcher)
+    label_override = bool(known_labels or unknown_labels)
+
+    # The request profile: an explicit request overrides the push throttles (Invariant 4). The
+    # capacity override is unconditional (Invariant 7) — the load line below carries the honest
+    # capacity signal instead.
+    override_kwargs: dict = {"auto_assign": True, "temporary_break": False, "maximum_capacity": sys.maxsize}
+    if label_override:
+        override_kwargs["preferred_labels"] = list(known_labels)
+        override_kwargs["preferred_labels_lower"] = set(known_labels)
+    requester = replace(profile, **override_kwargs)
+    effective_labels = list(known_labels) if label_override else list(profile.preferred_labels)
+
+    # The load line comes from the same payload but the REAL preference capacity — never the
+    # sys.maxsize override (Invariant 7) — and is computed even for degenerate statuses below so
+    # surfaces can always render it.
+    load = reviewer_load_for(repository, requester_norm, snapshot_payload=payload, now=current_time)
+
+    common = dict(
+        effective_labels=effective_labels,
+        label_override=label_override,
+        unknown_labels=unknown_labels,
+        load=load,
+        snapshot_generated_at=generated_at,
+    )
+    if not requester.preferred_labels_lower:
+        return _result(status=STATUS_NO_LABELS, **common)
+
+    # Every downstream engine call sees the override — the substitution is the whole of the
+    # "explicit request" semantics; the engine itself is unmodified.
+    catalog = [requester if _normalize_login(r.github_login) == requester_norm else r for r in inputs.reviewers]
+    all_prs = payload.get("prs", {})
+
+    ranked_prs, ranking_trace = rank_prs_for_assignment(
+        prs_to_assign=inputs.assignable_queue_prs,
+        all_prs=all_prs,
+        reviewers=catalog,
+        assignment_stats=inputs.assignments,
+        excluded_by_pr=inputs.excluded_by_pr,
+        topic_label_matcher=matcher,
+    )
+
+    # A fixed local RNG: the engine's weighted draw ("picked") is computed but never read
+    # (Invariant 2); seeding locally also keeps this read path from consuming global randomness.
+    rng = random.Random(0)
+    suggestions: list[SuggestedPR] = []
+    skipped: dict[str, int] = {}
+    # Walk the whole ranking (cheap next to the payload read) so the skip tally covers the entire
+    # assignable pool; suggestions stop accumulating at `limit`.
+    for pr_number in ranked_prs:
+        pr_entry = all_prs.get(pr_number) or all_prs.get(str(pr_number))
+        if not pr_entry:
+            continue
+        # The pool's active-assignee filter reads *real* availability, so an away/auto-assign-off
+        # requester's own assigned PRs survive into the shared pool. Never offer a reviewer a PR
+        # they are already assigned to (mirrors the pool filter, scoped to the requester).
+        assignees_norm = {_normalize_login(str(login)) for login in (pr_entry.get("assignees") or []) if login}
+        if requester_norm in assignees_norm:
+            skipped[SKIP_ALREADY_ASSIGNED] = skipped.get(SKIP_ALREADY_ASSIGNED, 0) + 1
+            continue
+        _unused_result, trace = suggest_reviewer_for_pr_with_trace(
+            pr_entry=pr_entry,
+            reviewers=catalog,
+            assignment_stats=inputs.assignments,
+            rng=rng,
+            excluded_logins=inputs.excluded_by_pr.get(pr_number),
+            topic_label_matcher=matcher,
+        )
+        available_norm = {_normalize_login(login) for login in trace.get("available", [])}
+        if requester_norm not in available_norm:
+            reason = _classify_skip(
+                pr_entry=pr_entry,
+                requester=requester,
+                requester_norm=requester_norm,
+                trace=trace,
+                matcher=matcher,
+            )
+            skipped[reason] = skipped.get(reason, 0) + 1
+            continue
+        if len(suggestions) >= effective_limit:
+            continue
+        details = (ranking_trace.get(str(pr_number)) or {}).get("details") or {}
+        topic_labels = _topic_labels(pr_entry, matcher)
+        queue_age = details.get("queue_age_seconds")
+        suggestions.append(
+            SuggestedPR(
+                pr_number=int(pr_number),
+                title=str(pr_entry.get("title") or ""),
+                url=f"https://github.com/{repository.owner}/{repository.name}/pull/{int(pr_number)}",
+                author_login=str(pr_entry.get("author") or ""),
+                topic_labels=topic_labels,
+                matched_labels=[lab for lab in topic_labels if lab.lower() in requester.preferred_labels_lower],
+                queue_age_seconds=float(queue_age) if queue_age is not None else None,
+                available_reviewer_count=int(details.get("available_reviewer_count") or 0),
+                load_weight=_compute_weight(int(pr_number), pr_entry),
+            )
+        )
+
+    return _result(
+        suggestions=suggestions,
+        skipped=skipped,
+        status=STATUS_OK if suggestions else STATUS_NONE_ELIGIBLE,
+        **common,
+    )
+
+
+__all__ = [
+    "SKIP_ALREADY_ASSIGNED",
+    "SKIP_AUTHORED",
+    "SKIP_CONFLICT_OF_INTEREST",
+    "SKIP_EXCLUDED",
+    "SKIP_NO_AREA_MATCH",
+    "SKIP_NO_TOPIC_LABEL",
+    "SKIP_OUTRANKED",
+    "STATUS_NO_LABELS",
+    "STATUS_NO_SNAPSHOT",
+    "STATUS_NONE_ELIGIBLE",
+    "STATUS_NOT_A_REVIEWER",
+    "STATUS_OK",
+    "SuggestedPR",
+    "SuggestionResult",
+    "suggest_prs_for_reviewer",
+]

--- a/qb_site/analyzer/services/reviewer_assignment.py
+++ b/qb_site/analyzer/services/reviewer_assignment.py
@@ -400,8 +400,8 @@ def suggest_reviewers_many_with_trace(
 
 
 @dataclass
-class _AssignmentInputs:
-    """Proposal-aware candidate/load inputs shared by the builder and the trace."""
+class AssignmentInputs:
+    """Proposal-aware candidate/load inputs shared by the builder, the trace, and suggestions."""
 
     reviewers: list[ReviewerProfile]
     assignments: Dict[str, tuple[list[int], float, int]]
@@ -410,13 +410,13 @@ class _AssignmentInputs:
     excluded_by_pr: dict[int, set[str]]
 
 
-def _prepare_assignment_inputs(
+def prepare_assignment_inputs(
     repository: Repository,
     *,
     payload: dict,
     now: datetime,
     rule_set: QueueRuleSet | None,
-) -> _AssignmentInputs:
+) -> AssignmentInputs:
     """Assemble the candidate pool, reviewer load, and exclusions for a build.
 
     Beyond the legacy filters (active-assignee / assignment-forbidden labels / opt-outs) this
@@ -425,6 +425,10 @@ def _prepare_assignment_inputs(
     proposal are withheld from re-proposal, and reviewers with a recently expired proposal for a
     PR are excluded for it (soft cooldown, merged into the per-PR exclusion set alongside
     opt-outs).
+
+    Public because on-demand assignment suggestions (design doc 053, Invariant 5) must share
+    this exact pool: any candidate filter added elsewhere would let suggestions offer PRs the
+    nightly builder refuses. New exclusion rules belong here, not at a call site.
     """
     reviewers = build_reviewer_catalog(repository, now=now)
     assignment_stats = collect_assignment_statistics(payload)
@@ -455,7 +459,7 @@ def _prepare_assignment_inputs(
         _opt_outs_for_prs(repository, assignable_queue_prs),
         _proposal_cooldowns_for_prs(repository, assignable_queue_prs, now=now, cooldown_days=cooldown_days),
     )
-    return _AssignmentInputs(
+    return AssignmentInputs(
         reviewers=reviewers,
         assignments=assignments,
         queue_prs=queue_prs,
@@ -474,7 +478,7 @@ def build_reviewer_assignment_trace(
     current_time = now or datetime.now(timezone.utc)
     payload = queue_snapshot.payload
     topic_label_matcher = topic_label_matcher_for_repo(repository)
-    inputs = _prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=None)
+    inputs = prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=None)
     queue_prs = inputs.queue_prs
     assignable_queue_prs = inputs.assignable_queue_prs
 
@@ -616,7 +620,7 @@ class ReviewerAssignmentBuilder:
         queue_obj = queue_snapshot or self._get_or_build_queue_snapshot(repository, cache_key=cache_key, rule_set=rule_set)
         payload = queue_obj.payload
 
-        inputs = _prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=rule_set)
+        inputs = prepare_assignment_inputs(repository, payload=payload, now=current_time, rule_set=rule_set)
 
         automatic_assignments = suggest_reviewers_many(
             reviewers=inputs.reviewers,
@@ -779,6 +783,7 @@ class AreaStatsBuilder:
 
 
 __all__ = [
+    "AssignmentInputs",
     "AssignmentStatistics",
     "AreaStatsBuilder",
     "PRAssignmentPriority",
@@ -792,6 +797,7 @@ __all__ = [
     "collect_assignment_statistics",
     "compute_area_stats",
     "pending_proposal_load_for_repo",
+    "prepare_assignment_inputs",
     "rank_prs_for_assignment",
     "suggest_reviewer_for_pr",
     "suggest_reviewers_many",

--- a/qb_site/analyzer/services/reviewer_assignment_engine.py
+++ b/qb_site/analyzer/services/reviewer_assignment_engine.py
@@ -314,6 +314,11 @@ def _pr_trace_base(
         "labels": _topic_labels(pr_entry, topic_label_matcher),
         "author": pr_entry.get("author") or "",
         "opt_outs": sorted(login for login in excluded_logins if login),
+        # Default so that `potential` is always present, including on the early-return paths
+        # (missing-topic-label / no-match / no-matching-labels) that never reach the candidate
+        # contest. Readers such as the 053 skip classifier key off membership in this list, and a
+        # missing key there is indistinguishable from "was contested and lost".
+        "potential": [],
     }
 
 
@@ -528,6 +533,7 @@ def run_assignment_simulation(
                         "author": "",
                         "opt_outs": [],
                         "candidate_counts": {"matching_label": 0, "after_exclusions": 0, "available_capacity": 0},
+                        "potential": [],
                         "available": [],
                         "picked": None,
                         "reason": "missing-pr",

--- a/qb_site/analyzer/tests/services/test_assignment_suggestions.py
+++ b/qb_site/analyzer/tests/services/test_assignment_suggestions.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone as dt_timezone
+
+from django.test import TestCase, override_settings
+
+from analyzer.models import AssignmentProposal, QueueRuleSet, QueueSnapshot, ReviewerOptOut
+from analyzer.services.assignment_suggestions import (
+    SKIP_ALREADY_ASSIGNED,
+    SKIP_AUTHORED,
+    SKIP_CONFLICT_OF_INTEREST,
+    SKIP_EXCLUDED,
+    SKIP_NO_AREA_MATCH,
+    SKIP_NO_TOPIC_LABEL,
+    SKIP_OUTRANKED,
+    STATUS_NO_LABELS,
+    STATUS_NO_SNAPSHOT,
+    STATUS_NONE_ELIGIBLE,
+    STATUS_NOT_A_REVIEWER,
+    STATUS_OK,
+    suggest_prs_for_reviewer,
+)
+from core.models import Repository, ReviewerPreference, User
+from syncer.models import LabelDef
+
+NOW = datetime(2026, 8, 1, 12, 0, tzinfo=dt_timezone.utc)
+
+
+def _pr(
+    *,
+    author: str = "zed",
+    labels: list[str] | None = None,
+    assignees: list[str] | None = None,
+    title: str = "chore: a change",
+    queue_age: float = 1000.0,
+) -> dict:
+    return {
+        "author": author,
+        "title": title,
+        "labels": [{"name": name} for name in (labels or [])],
+        "assignees": assignees or [],
+        "pr_status": "AwaitingReview",
+        "total_queue_time": {"status": "valid", "value_td": queue_age},
+    }
+
+
+class SuggestionServiceTestCase(TestCase):
+    """Shared fixture: a repo with a default rule set, a label catalog, and two reviewers."""
+
+    def setUp(self) -> None:
+        self.repo = Repository.objects.create(owner="leanprover-community", name="mathlib4", default_branch="master")
+        self.rules = QueueRuleSet.objects.create(
+            repository=self.repo,
+            version=1,
+            require_open=True,
+            require_not_draft=True,
+            require_ci_success=False,
+            required_label_names=[],
+            forbidden_label_names=[],
+            is_active=True,
+        )
+        for name in ("t-algebra", "t-topology", "t-order", "easy"):
+            LabelDef.objects.create(repository=self.repo, name=name, color="ededed")
+        alice = User.objects.create(github_login="alice", zulip_user_id=101)
+        bob = User.objects.create(github_login="bob", zulip_user_id=102)
+        self.alice_pref = ReviewerPreference.objects.create(
+            user=alice, repository=self.repo, maximum_capacity=10, preferred_labels=["t-algebra"]
+        )
+        self.bob_pref = ReviewerPreference.objects.create(
+            user=bob, repository=self.repo, maximum_capacity=10, preferred_labels=["t-algebra", "t-topology"]
+        )
+
+    def _seed_snapshot(self, prs: dict[str, dict], *, queue: list[int] | None = None) -> None:
+        queue_prs = queue if queue is not None else [int(n) for n in prs]
+        QueueSnapshot.objects.create(
+            repository=self.repo,
+            cache_key=str(self.rules.id),
+            generated_at=datetime(2026, 8, 1, tzinfo=dt_timezone.utc),
+            payload={
+                "meta": {"generated_at": "2026-08-01T00:00:00+00:00"},
+                "prs": prs,
+                "lists": {"dashboards": {"Queue": queue_prs}},
+            },
+            etag="etag",
+            pr_count=len(prs),
+            queue_count=len(queue_prs),
+        )
+
+    def _suggest(self, login: str = "alice", **kwargs):
+        kwargs.setdefault("now", NOW)
+        return suggest_prs_for_reviewer(self.repo, login, **kwargs)
+
+
+class TestStatuses(SuggestionServiceTestCase):
+    def test_no_snapshot_returns_no_suggestions_not_an_empty_success(self) -> None:
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NO_SNAPSHOT)
+        self.assertEqual(result.suggestions, [])
+        self.assertIsNone(result.snapshot_generated_at)
+        self.assertIsNone(result.load)
+
+    def test_not_a_reviewer(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest("stranger")
+        self.assertEqual(result.status, STATUS_NOT_A_REVIEWER)
+        self.assertEqual(result.suggestions, [])
+
+    def test_no_labels_when_reviewer_has_none_and_no_override(self) -> None:
+        self.alice_pref.preferred_labels = []
+        self.alice_pref.save(update_fields=["preferred_labels"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NO_LABELS)
+        self.assertEqual(result.suggestions, [])
+        # The load line is still available for rendering.
+        self.assertIsNotNone(result.load)
+
+    def test_no_labels_when_override_is_entirely_unknown(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=["t-nonexistent"])
+        self.assertEqual(result.status, STATUS_NO_LABELS)
+        self.assertTrue(result.label_override)
+        self.assertEqual(result.unknown_labels, ["t-nonexistent"])
+        self.assertEqual(result.effective_labels, [])
+
+    def test_none_eligible_carries_the_skip_tally(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-order"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.suggestions, [])
+        self.assertEqual(result.skipped, {SKIP_NO_AREA_MATCH: 1})
+
+    def test_ok_result_shape(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"], title="feat: rings", queue_age=123.0)})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_OK)
+        self.assertEqual(result.reviewer_login, "alice")
+        self.assertEqual(result.repository_id, self.repo.id)
+        self.assertIsNotNone(result.snapshot_generated_at)
+        [pr] = result.suggestions
+        self.assertEqual(pr.pr_number, 1)
+        self.assertEqual(pr.title, "feat: rings")
+        self.assertEqual(pr.url, "https://github.com/leanprover-community/mathlib4/pull/1")
+        self.assertEqual(pr.author_login, "zed")
+        self.assertEqual(pr.topic_labels, ["t-algebra"])
+        self.assertEqual(pr.matched_labels, ["t-algebra"])
+        self.assertEqual(pr.queue_age_seconds, 123.0)
+        # alice and bob both match t-algebra and both have room.
+        self.assertEqual(pr.available_reviewer_count, 2)
+        # AwaitingReview -> claiming adds a full slot.
+        self.assertEqual(pr.load_weight, 1.0)
+
+
+class TestOrderingAndLimits(SuggestionServiceTestCase):
+    def _seed_six_algebra_prs(self) -> None:
+        # Same label/scarcity for all six -> the ranking is decided by queue age (oldest first).
+        self._seed_snapshot({str(n): _pr(labels=["t-algebra"], queue_age=float(1000 * (7 - n))) for n in range(1, 7)})
+
+    def test_ordering_matches_the_scheduled_ranking_and_limit_is_respected(self) -> None:
+        self._seed_six_algebra_prs()
+        result = self._suggest(limit=4)
+        self.assertEqual([s.pr_number for s in result.suggestions], [1, 2, 3, 4])
+
+    def test_prefix_property(self) -> None:
+        # The same request at limit=3 returns exactly the first three of limit=6 (Invariant 2):
+        # this is the promise the Zulip footer's console link makes.
+        self._seed_six_algebra_prs()
+        short = self._suggest(limit=3)
+        long = self._suggest(limit=6)
+        self.assertEqual(
+            [s.pr_number for s in short.suggestions],
+            [s.pr_number for s in long.suggestions][:3],
+        )
+        self.assertEqual(len(long.suggestions), 6)
+
+    def test_determinism_engine_random_draw_never_leaks_in(self) -> None:
+        self._seed_six_algebra_prs()
+        first = self._suggest(limit=6)
+        second = self._suggest(limit=6)
+        self.assertEqual(first.suggestions, second.suggestions)
+        self.assertEqual(first.skipped, second.skipped)
+
+    def test_queue_age_ties_break_by_pr_number(self) -> None:
+        self._seed_snapshot(
+            {
+                "9": _pr(labels=["t-algebra"], queue_age=500.0),
+                "3": _pr(labels=["t-algebra"], queue_age=500.0),
+            }
+        )
+        result = self._suggest()
+        self.assertEqual([s.pr_number for s in result.suggestions], [3, 9])
+
+    def test_skip_tally_covers_the_whole_pool_even_past_the_limit(self) -> None:
+        self._seed_snapshot(
+            {
+                "1": _pr(labels=["t-algebra"], queue_age=3000.0),
+                "2": _pr(labels=["t-algebra"], queue_age=2000.0),
+                "3": _pr(labels=["t-order"], queue_age=1000.0),
+            }
+        )
+        result = self._suggest(limit=1)
+        self.assertEqual(len(result.suggestions), 1)
+        self.assertEqual(result.skipped, {SKIP_NO_AREA_MATCH: 1})
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT=2)
+    def test_default_limit_comes_from_settings(self) -> None:
+        self._seed_six_algebra_prs()
+        result = self._suggest()
+        self.assertEqual(len(result.suggestions), 2)
+
+
+class TestLabelOverride(SuggestionServiceTestCase):
+    def test_override_replaces_stored_preferred_labels(self) -> None:
+        self._seed_snapshot(
+            {
+                "1": _pr(labels=["t-algebra"]),
+                "2": _pr(labels=["t-order"]),
+            }
+        )
+        result = self._suggest(labels=["t-order"])
+        self.assertTrue(result.label_override)
+        self.assertEqual(result.effective_labels, ["t-order"])
+        self.assertEqual([s.pr_number for s in result.suggestions], [2])
+        # The stored t-algebra interest does not leak through: PR 1 is a no_area_match skip.
+        self.assertEqual(result.skipped, {SKIP_NO_AREA_MATCH: 1})
+
+    def test_no_override_uses_stored_labels(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertFalse(result.label_override)
+        self.assertEqual(result.effective_labels, ["t-algebra"])
+        self.assertEqual(result.unknown_labels, [])
+
+    def test_unknown_labels_reported_known_ones_still_used(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        # "t-typo" matches the topic pattern but is not in the repo's label catalog;
+        # "easy" is in the catalog but is not a topic label.
+        result = self._suggest(labels=["t-typo", "easy", "t-algebra"])
+        self.assertEqual(result.unknown_labels, ["t-typo", "easy"])
+        self.assertEqual(result.effective_labels, ["t-algebra"])
+        self.assertEqual([s.pr_number for s in result.suggestions], [1])
+
+    def test_labels_are_normalized_and_deduped(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=[" T-Algebra ", "t-algebra", ""])
+        self.assertEqual(result.effective_labels, ["t-algebra"])
+        self.assertEqual(result.unknown_labels, [])
+
+    def test_blank_only_override_is_no_override(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=["", "   "])
+        self.assertFalse(result.label_override)
+        self.assertEqual(result.effective_labels, ["t-algebra"])
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=2)
+    def test_max_labels_cap_is_enforced(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-order"])})
+        result = self._suggest(labels=["t-algebra", "t-topology", "t-order"])
+        # Only the first two survive the cap; the dropped t-order means PR 1 is not offered.
+        self.assertEqual(result.effective_labels, ["t-algebra", "t-topology"])
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+
+
+class TestOverridesAndCorrectnessRules(SuggestionServiceTestCase):
+    def test_away_until_is_overridden(self) -> None:
+        self.alice_pref.away_until = NOW + timedelta(days=30)
+        self.alice_pref.save(update_fields=["away_until"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertEqual([s.pr_number for s in result.suggestions], [1])
+
+    def test_auto_assign_off_is_overridden(self) -> None:
+        self.alice_pref.auto_assign = False
+        self.alice_pref.save(update_fields=["auto_assign"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertEqual([s.pr_number for s in result.suggestions], [1])
+
+    def test_capacity_is_overridden_but_the_load_line_reports_the_real_capacity(self) -> None:
+        # alice is pinned at her cap by an existing assignment; an explicit request still yields
+        # suggestions (Invariant 7), the load line stays honest, and there is never an
+        # at_capacity skip for the requester.
+        self.alice_pref.maximum_capacity = 1
+        self.alice_pref.auto_assign = False  # keep her assigned PR in the pool via inactivity
+        self.alice_pref.save(update_fields=["maximum_capacity", "auto_assign"])
+        self._seed_snapshot(
+            {
+                "1": _pr(labels=["t-algebra"], assignees=["alice"]),
+                "2": _pr(labels=["t-algebra"]),
+            }
+        )
+        result = self._suggest()
+        self.assertEqual([s.pr_number for s in result.suggestions], [2])
+        self.assertIsNotNone(result.load)
+        self.assertEqual(result.load.capacity, 1)
+        self.assertEqual(result.load.current_load, 1.0)
+        self.assertTrue(result.load.at_capacity)
+        self.assertNotIn("at_capacity", result.skipped)
+
+    def test_own_assigned_pr_is_never_suggested_back(self) -> None:
+        # The pool's active-assignee filter reads real availability, so an auto_assign-off
+        # requester's own assigned PR survives into the pool; the walk must still skip it.
+        self.alice_pref.auto_assign = False
+        self.alice_pref.save(update_fields=["auto_assign"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"], assignees=["alice"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_ALREADY_ASSIGNED: 1})
+
+    def test_authorship_is_not_overridden(self) -> None:
+        self._seed_snapshot({"1": _pr(author="alice", labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_AUTHORED: 1})
+
+    def test_conflict_of_interest_is_not_overridden(self) -> None:
+        self.alice_pref.conflict_of_interest = ["zed"]
+        self.alice_pref.save(update_fields=["conflict_of_interest"])
+        self._seed_snapshot({"1": _pr(author="zed", labels=["t-algebra"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_CONFLICT_OF_INTEREST: 1})
+
+    def test_opt_out_is_not_overridden(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        ReviewerOptOut.objects.create(
+            repository=self.repo, pr_number=1, reviewer_login="alice", active=True, opted_out_at=NOW - timedelta(days=1)
+        )
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_EXCLUDED: 1})
+
+    def test_expired_proposal_cooldown_is_not_overridden(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        AssignmentProposal.objects.create(
+            repository=self.repo,
+            pr_number=1,
+            reviewer_login="alice",
+            state=AssignmentProposal.STATE_EXPIRED,
+            expires_at=NOW - timedelta(days=2),
+            decided_at=NOW - timedelta(days=2),
+        )
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_EXCLUDED: 1})
+
+    def test_pr_with_active_proposal_is_not_in_the_pool_at_all(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        AssignmentProposal.objects.create(
+            repository=self.repo,
+            pr_number=1,
+            reviewer_login="bob",
+            state=AssignmentProposal.STATE_PROPOSED,
+            expires_at=NOW + timedelta(days=7),
+        )
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        # Withheld by the shared pool filter, so it is not even a skip.
+        self.assertEqual(result.skipped, {})
+
+
+class TestSkipTally(SuggestionServiceTestCase):
+    def test_no_topic_label(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=[])})
+        result = self._suggest()
+        self.assertEqual(result.skipped, {SKIP_NO_TOPIC_LABEL: 1})
+
+    def test_outranked_on_a_multi_label_pr(self) -> None:
+        # bob matches both labels, alice one: the engine's max_score contest drops alice.
+        self._seed_snapshot({"1": _pr(labels=["t-algebra", "t-topology"])})
+        result = self._suggest()
+        self.assertEqual(result.status, STATUS_NONE_ELIGIBLE)
+        self.assertEqual(result.skipped, {SKIP_OUTRANKED: 1})
+
+    def test_broad_label_override_is_never_outranked(self) -> None:
+        # Matching every label on the PR always ties max_score (Invariant 9).
+        self._seed_snapshot({"1": _pr(labels=["t-algebra", "t-topology"])})
+        result = self._suggest(labels=["t-algebra", "t-topology"])
+        self.assertEqual([s.pr_number for s in result.suggestions], [1])
+        self.assertNotIn(SKIP_OUTRANKED, result.skipped)
+        self.assertEqual(result.suggestions[0].matched_labels, ["t-algebra", "t-topology"])

--- a/qb_site/analyzer/tests/services/test_assignment_suggestions.py
+++ b/qb_site/analyzer/tests/services/test_assignment_suggestions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from datetime import datetime, timedelta, timezone as dt_timezone
 
 from django.test import TestCase, override_settings
@@ -20,6 +21,7 @@ from analyzer.services.assignment_suggestions import (
     STATUS_OK,
     suggest_prs_for_reviewer,
 )
+from analyzer.services.reviewer_assignment_engine import ReviewerProfile, suggest_reviewer_for_pr_with_trace
 from core.models import Repository, ReviewerPreference, User
 from syncer.models import LabelDef
 
@@ -149,6 +151,143 @@ class TestStatuses(SuggestionServiceTestCase):
         self.assertEqual(pr.available_reviewer_count, 2)
         # AwaitingReview -> claiming adds a full slot.
         self.assertEqual(pr.load_weight, 1.0)
+
+
+class TestLabelOverrideCap(SuggestionServiceTestCase):
+    """Labels past MAX_LABELS are reported, not silently honoured-in-part."""
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=2)
+    def test_labels_past_the_cap_are_reported(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=["t-algebra", "t-topology", "t-order"])
+        self.assertEqual(result.effective_labels, ["t-algebra", "t-topology"])
+        self.assertEqual(result.dropped_labels, ["t-order"])
+        self.assertEqual(result.unknown_labels, [])
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=2)
+    def test_dropped_is_distinct_from_unknown(self) -> None:
+        # A typo inside the cap is `unknown`; a good label past the cap is `dropped`. Collapsing
+        # the two would tell a reviewer their own label was wrong when it was merely refused.
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=["t-algebra", "t-nonexistent", "t-topology"])
+        self.assertEqual(result.effective_labels, ["t-algebra"])
+        self.assertEqual(result.unknown_labels, ["t-nonexistent"])
+        self.assertEqual(result.dropped_labels, ["t-topology"])
+
+    def test_nothing_is_dropped_within_the_cap(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(labels=["t-algebra"])
+        self.assertEqual(result.dropped_labels, [])
+
+
+class TestSnapshotStaleness(SuggestionServiceTestCase):
+    """A stale snapshot is refused like a missing one — it must not be served as live."""
+
+    def test_snapshot_older_than_the_ceiling_is_refused(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(now=datetime(2026, 9, 1, tzinfo=dt_timezone.utc))
+        self.assertEqual(result.status, STATUS_NO_SNAPSHOT)
+        self.assertEqual(result.suggestions, [])
+        # Still reported, so an operator can see *how* stale rather than just "missing".
+        self.assertIsNotNone(result.snapshot_generated_at)
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS=0)
+    def test_zero_disables_the_ceiling(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest(now=datetime(2026, 9, 1, tzinfo=dt_timezone.utc))
+        self.assertEqual(result.status, STATUS_OK)
+
+    def test_a_fresh_snapshot_is_served(self) -> None:
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        self.assertEqual(self._suggest().status, STATUS_OK)
+
+
+class TestEngineTraceContract(TestCase):
+    """`_classify_skip` reads `trace["potential"]`; every trace shape must carry the key.
+
+    Without it, the three early-return paths were indistinguishable from "was contested and
+    lost", which would silently misattribute skips to `outranked` — the one reason a reviewer
+    cannot verify from the PR itself.
+    """
+
+    def _profile(self, login: str, labels: list[str]) -> ReviewerProfile:
+        return ReviewerProfile(
+            github_login=login,
+            maximum_capacity=10,
+            auto_assign=True,
+            temporary_break=False,
+            preferred_labels=labels,
+            preferred_labels_lower={lab.lower() for lab in labels},
+            free_form="",
+            conflict_of_interest=[],
+            conflict_of_interest_lower=set(),
+        )
+
+    def _trace(self, pr_entry: dict, reviewers: list[ReviewerProfile]) -> dict:
+        _result, trace = suggest_reviewer_for_pr_with_trace(
+            pr_entry=pr_entry, reviewers=reviewers, assignment_stats={}, rng=random.Random(0)
+        )
+        return trace
+
+    def test_missing_topic_label_path_carries_potential(self) -> None:
+        trace = self._trace(_pr(labels=[]), [self._profile("alice", ["t-algebra"])])
+        self.assertEqual(trace["reason"], "missing-topic-label")
+        self.assertIn("potential", trace)
+        self.assertEqual(trace["potential"], [])
+
+    def test_no_match_path_carries_potential(self) -> None:
+        trace = self._trace(_pr(labels=["t-order"]), [self._profile("alice", ["t-algebra"])])
+        self.assertEqual(trace["reason"], "no-match")
+        self.assertIn("potential", trace)
+        self.assertEqual(trace["potential"], [])
+
+    def test_success_path_still_reports_real_potential(self) -> None:
+        trace = self._trace(_pr(labels=["t-algebra"]), [self._profile("alice", ["t-algebra"])])
+        self.assertEqual(trace["potential"], ["alice"])
+        self.assertEqual(trace["available"], ["alice"])
+
+
+class TestScarcityCount(SuggestionServiceTestCase):
+    """`available_reviewer_count` reports the REAL supply, not the requester's override."""
+
+    def test_unavailable_requester_is_not_counted_as_available_supply(self) -> None:
+        # Alice is off auto-assign: the request overrides that for *her* eligibility (she still
+        # gets the suggestion), but the nightly run would not count her as available supply, so
+        # neither may the rendered scarcity number. Only bob really matches and has room.
+        self.alice_pref.auto_assign = False
+        self.alice_pref.save(update_fields=["auto_assign"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        [pr] = result.suggestions
+        self.assertEqual(pr.available_reviewer_count, 1)
+
+    def test_requester_at_capacity_is_not_counted_as_available_supply(self) -> None:
+        # Same for the capacity override — the other half of Invariant 7's "reported, never
+        # enforced": alice is suggested the PR, but she is not supply for it.
+        self.alice_pref.maximum_capacity = 0
+        self.alice_pref.save(update_fields=["maximum_capacity"])
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        [pr] = result.suggestions
+        self.assertEqual(pr.available_reviewer_count, 1)
+
+    def test_available_requester_is_counted(self) -> None:
+        # The control: with alice genuinely available, she counts alongside bob.
+        self._seed_snapshot({"1": _pr(labels=["t-algebra"])})
+        result = self._suggest()
+        [pr] = result.suggestions
+        self.assertEqual(pr.available_reviewer_count, 2)
+
+    def test_scarcity_is_zero_when_no_one_is_really_available(self) -> None:
+        # A PR only the unavailable requester matches reports 0 available reviewers — the signal
+        # the old reading could never produce, since the override always counted at least one.
+        self.alice_pref.auto_assign = False
+        self.alice_pref.preferred_labels = ["t-order"]
+        self.alice_pref.save(update_fields=["auto_assign", "preferred_labels"])
+        self._seed_snapshot({"1": _pr(labels=["t-order"])})
+        result = self._suggest()
+        [pr] = result.suggestions
+        self.assertEqual(pr.available_reviewer_count, 0)
 
 
 class TestOrderingAndLimits(SuggestionServiceTestCase):

--- a/qb_site/console/AGENTS.md
+++ b/qb_site/console/AGENTS.md
@@ -131,6 +131,32 @@
   per-PR sync per success, and renders `unassigned.html` with the removed/failed split (partial
   failures are contained, not fatal).
 
+## Suggestions page + claim (`views.suggestions` / `views.claim`, design doc 053)
+- `/console/suggestions/` ("Find PRs to review", `console:suggestions`) renders on-demand
+  assignment suggestions per repo from the single authority
+  `analyzer.services.assignment_suggestions.suggest_prs_for_reviewer` — the console never
+  re-derives eligibility. Read path is gated by `ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED`; linked
+  from the home header row and the home empty state (which was previously a dead end).
+- `?repo=<id>` and `?labels=a,b` pre-fill the request (the Zulip `suggest-prs` footer link carries
+  them) but are **validated, never trusted**: the repo must be one the session reviewer has a
+  `ReviewerPreference` in (otherwise ignored), and labels go through the service's
+  `ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS` cap and unknown-label reporting. The reviewer whose
+  suggestions are computed is always the session reviewer.
+- Each repo section shows the honest load line (`reviewer_load`-derived, the reviewer's *real*
+  capacity — never the request's capacity override; Invariant 7), a label-override search form, the
+  suggestion rows (matched labels highlighted, queue age, scarcity, per-PR load contribution), and
+  the `format_skip_summary` "why not more?" line.
+- `POST /console/suggestions/claim/` (`console:claim`, gated by
+  `ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED` on top of the read flag) takes
+  `repo_id` + `pr_numbers[]` + the `labels` override the offer was made under. Every posted number
+  is **re-verified against a fresh `suggest_prs_for_reviewer` run** before any GitHub write
+  (Invariant 6 — without it this endpoint degrades into a general self-assign API bypassing
+  conflict-of-interest/opt-out rules), and the login assigned is always the session reviewer's own.
+  Assignment reuses the 046 path (`assign_reviewer_and_record`, `assign_pr` operation token,
+  `snapshot=None`), with the same "did it land?" semantics as accept. Partial failures render as an
+  assigned/failed split (`claimed.html`), which also surfaces co-assignees — there is no hold on a
+  suggested PR (Invariant 8), so two claimers legally share the assignee set.
+
 ## Base URL
 - Absolute links (the DM console URL, the OAuth `redirect_uri`) come from
   `core.services.site_urls.build_site_url`, which resolves `QUEUEBOARD_BASE_URL`. Do not read the

--- a/qb_site/console/static/console/console.css
+++ b/qb_site/console/static/console/console.css
@@ -285,6 +285,46 @@ button.btn-unassign:hover {
   background: var(--bg);
 }
 
+/* On-demand suggestions page (design doc 053). Built on the shared tokens like everything else. */
+.suggestions-scope {
+  margin: 0 0 12px;
+}
+
+.label-override {
+  margin: 12px 0;
+}
+
+.label-override label {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.label-override-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.label-override-row input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  color: var(--ink);
+}
+
+/* A topic label that matches the effective label set for this search. */
+.pr-label.matched {
+  background: var(--accent);
+  color: var(--card);
+  font-weight: 600;
+}
+
 @media (max-width: 760px) {
   .actions {
     flex-direction: column;
@@ -296,5 +336,9 @@ button.btn-unassign:hover {
   .cta-quiet {
     width: 100%;
     text-align: center;
+  }
+
+  .label-override-row {
+    flex-direction: column;
   }
 }

--- a/qb_site/console/tests/test_suggestions.py
+++ b/qb_site/console/tests/test_suggestions.py
@@ -1,0 +1,244 @@
+"""Console suggestions + claim view tests (design doc 053).
+
+GitHub is mocked (`assign_reviewer_and_record`, operation tokens); sessions are seeded directly.
+The suggestion *service* itself runs for real against a seeded queue snapshot, so the claim
+re-verification (Invariant 6) is exercised end to end rather than mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from analyzer.models import QueueSnapshot, ReviewerAssignmentApplication
+from console.session import SESSION_USER_KEY
+from core.models import Repository, ReviewerPreference, User
+from syncer.models import LabelDef
+
+
+def _pr_entry(*, author: str = "zed", labels: list[str], assignees: list[str] | None = None, title: str = "a change") -> dict:
+    return {
+        "author": author,
+        "title": title,
+        "labels": [{"name": name} for name in labels],
+        "assignees": assignees or [],
+        "pr_status": "AwaitingReview",
+        "total_queue_time": {"status": "valid", "value_td": 1000.0},
+    }
+
+
+@override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED=True, ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED=True)
+class SuggestionViewTests(TestCase):
+    def setUp(self) -> None:
+        self.repo = Repository.objects.create(owner="leanprover-community", name="mathlib4", default_branch="master")
+        self.now = timezone.now()
+        self.reviewer = User.objects.create(github_login="bob", github_node_id="node-bob", zulip_user_id=7001)
+        ReviewerPreference.objects.create(
+            repository=self.repo,
+            user=self.reviewer,
+            preferred_labels=["t-analysis"],
+            maximum_capacity=5,
+        )
+        for name in ("t-analysis", "t-algebra"):
+            LabelDef.objects.create(repository=self.repo, name=name, color="ededed")
+
+    def _login_session(self, user: User | None = None) -> None:
+        session = self.client.session
+        session[SESSION_USER_KEY] = int((user or self.reviewer).id)
+        session.save()
+
+    def _seed_snapshot(self, prs: dict[str, dict]) -> None:
+        QueueSnapshot.objects.create(
+            repository=self.repo,
+            cache_key="default",  # no QueueRuleSet in these tests
+            generated_at=self.now,
+            payload={
+                "meta": {"generated_at": self.now.isoformat()},
+                "prs": prs,
+                "lists": {"dashboards": {"Queue": [int(n) for n in prs]}},
+            },
+            etag="etag",
+            pr_count=len(prs),
+            queue_count=len(prs),
+        )
+
+    def _seed_default_snapshot(self) -> None:
+        self._seed_snapshot(
+            {
+                "101": _pr_entry(labels=["t-analysis"], title="analysis PR"),
+                "102": _pr_entry(labels=["t-algebra"], title="algebra PR"),
+            }
+        )
+
+    # ---- suggestions page ------------------------------------------------
+
+    def test_requires_session(self) -> None:
+        response = self.client.get(reverse("console:suggestions"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("console:login"), response["Location"])
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED=False)
+    def test_read_path_is_flag_gated(self) -> None:
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"))
+        self.assertContains(response, "aren’t enabled yet")
+
+    def test_renders_suggestions_for_the_session_reviewer(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"))
+        self.assertContains(response, "analysis PR")
+        self.assertNotContains(response, "algebra PR")  # outside bob's areas
+        self.assertContains(response, "Load:")
+
+    def test_labels_param_prefills_and_overrides(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"), {"labels": "t-algebra"})
+        self.assertContains(response, "algebra PR")
+        self.assertNotContains(response, "analysis PR")  # override replaces stored labels
+        self.assertContains(response, 'value="t-algebra"')
+
+    def test_unknown_labels_are_reported_not_trusted(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"), {"labels": "t-typo,t-algebra"})
+        self.assertContains(response, "Not topic labels in this repository")
+        self.assertContains(response, "t-typo")
+        self.assertContains(response, "algebra PR")
+
+    def test_bogus_repo_param_is_ignored(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"), {"repo": "999999"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "leanprover-community/mathlib4")
+
+    def test_no_snapshot_renders_explanation(self) -> None:
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"))
+        self.assertContains(response, "No queue snapshot is available")
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED=False)
+    def test_claim_form_hidden_when_claim_disabled(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"))
+        self.assertContains(response, "analysis PR")
+        self.assertNotContains(response, 'name="pr_numbers"')
+
+    def test_home_links_to_suggestions_including_empty_state(self) -> None:
+        self._login_session()
+        response = self.client.get(reverse("console:home"))
+        self.assertContains(response, "Find PRs to review")
+        self.assertContains(response, reverse("console:suggestions"))
+
+    # ---- claim -----------------------------------------------------------
+
+    def _claim(self, pr_numbers: list[int], **extra):
+        data = {"repo_id": str(self.repo.id), "pr_numbers": [str(n) for n in pr_numbers]}
+        data.update(extra)
+        return self.client.post(reverse("console:claim"), data)
+
+    def test_claim_assigns_via_the_046_path(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch("console.views.assign_reviewer_and_record", return_value=("applied", None, None)) as mock_assign,
+        ):
+            response = self._claim([101])
+        self.assertContains(response, "Assigned you to")
+        self.assertContains(response, "#101")
+        mock_assign.assert_called_once()
+        kwargs = mock_assign.call_args.kwargs
+        self.assertEqual(kwargs["pr_number"], 101)
+        self.assertEqual(kwargs["login"], "bob")
+        self.assertIsNone(kwargs["snapshot"])
+
+    def test_claim_login_always_comes_from_the_session(self) -> None:
+        # A posted login/reviewer field is ignored: the assigned login is the session reviewer's.
+        self._seed_default_snapshot()
+        self._login_session()
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch("console.views.assign_reviewer_and_record", return_value=("applied", None, None)) as mock_assign,
+        ):
+            self._claim([101], login="eve", reviewer_login="eve")
+        self.assertEqual(mock_assign.call_args.kwargs["login"], "bob")
+
+    def test_claim_rejects_a_number_not_in_the_fresh_eligible_set(self) -> None:
+        # 102 is outside bob's areas, 999 is not in the pool at all: neither may reach GitHub.
+        self._seed_default_snapshot()
+        self._login_session()
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch("console.views.assign_reviewer_and_record") as mock_assign,
+        ):
+            response = self._claim([102, 999])
+        mock_assign.assert_not_called()
+        self.assertContains(response, "Could not assign")
+        self.assertContains(response, "no longer eligible")
+
+    def test_claim_partial_failure_renders_the_split(self) -> None:
+        self._seed_snapshot(
+            {
+                "101": _pr_entry(labels=["t-analysis"], title="analysis PR"),
+                "103": _pr_entry(labels=["t-analysis"], title="second analysis PR"),
+            }
+        )
+        self._login_session()
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch(
+                "console.views.assign_reviewer_and_record",
+                side_effect=[("applied", None, None), ("failed", None, None)],
+            ),
+        ):
+            response = self._claim([101, 103])
+        self.assertContains(response, "Assigned you to")
+        self.assertContains(response, "#101")
+        self.assertContains(response, "Could not assign")
+        self.assertContains(response, "#103")
+        self.assertContains(response, "didn’t confirm")
+
+    def test_claim_already_recorded_counts_only_when_applied(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        failed_record = ReviewerAssignmentApplication(status=ReviewerAssignmentApplication.STATUS_FAILED)
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch("console.views.assign_reviewer_and_record", return_value=("already_recorded", None, failed_record)),
+        ):
+            response = self._claim([101])
+        self.assertContains(response, "Could not assign")
+
+    def test_claim_respects_the_label_override_it_was_offered_under(self) -> None:
+        # The offer came from ?labels=t-algebra; the re-check must run the same question,
+        # or PR 102 (outside bob's stored areas) would wrongly fail eligibility.
+        self._seed_default_snapshot()
+        self._login_session()
+        with (
+            patch("core.services.github_operation_tokens.resolve_github_app_operation_token", return_value="tok"),
+            patch("console.views.assign_reviewer_and_record", return_value=("applied", None, None)) as mock_assign,
+        ):
+            response = self._claim([102], labels="t-algebra")
+        self.assertContains(response, "Assigned you to")
+        self.assertEqual(mock_assign.call_args.kwargs["pr_number"], 102)
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED=False)
+    def test_claim_is_flag_gated(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        with patch("console.views.assign_reviewer_and_record") as mock_assign:
+            response = self._claim([101])
+        mock_assign.assert_not_called()
+        self.assertContains(response, "isn’t enabled yet")
+
+    def test_claim_requires_session(self) -> None:
+        response = self._claim([101])
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("console:login"), response["Location"])

--- a/qb_site/console/tests/test_suggestions.py
+++ b/qb_site/console/tests/test_suggestions.py
@@ -117,6 +117,14 @@ class SuggestionViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "leanprover-community/mathlib4")
 
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=1)
+    def test_labels_over_the_cap_are_reported_on_the_page(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        response = self.client.get(reverse("console:suggestions"), {"labels": "t-analysis, t-algebra"})
+        self.assertContains(response, "Too many labels")
+        self.assertContains(response, "t-algebra")
+
     def test_no_snapshot_renders_explanation(self) -> None:
         self._login_session()
         response = self.client.get(reverse("console:suggestions"))
@@ -242,3 +250,21 @@ class SuggestionViewTests(TestCase):
         response = self._claim([101])
         self.assertEqual(response.status_code, 302)
         self.assertIn(reverse("console:login"), response["Location"])
+
+    def test_claim_rejects_a_non_numeric_repo_id_without_erroring(self) -> None:
+        # An `id=` lookup against a non-numeric string raises ValueError inside the ORM, which
+        # would surface as a 500 rather than the not-found branch.
+        self._seed_default_snapshot()
+        self._login_session()
+        with patch("console.views.assign_reviewer_and_record") as mock_assign:
+            response = self.client.post(reverse("console:claim"), {"repo_id": "not-a-number", "pr_numbers": ["101"]})
+        mock_assign.assert_not_called()
+        self.assertEqual(response.status_code, 404)
+
+    def test_claim_rejects_an_unknown_repo_id(self) -> None:
+        self._seed_default_snapshot()
+        self._login_session()
+        with patch("console.views.assign_reviewer_and_record") as mock_assign:
+            response = self.client.post(reverse("console:claim"), {"repo_id": "999999", "pr_numbers": ["101"]})
+        mock_assign.assert_not_called()
+        self.assertEqual(response.status_code, 404)

--- a/qb_site/console/urls.py
+++ b/qb_site/console/urls.py
@@ -18,4 +18,6 @@ urlpatterns = [
     path("proposals/<int:proposal_id>/assign-anyway/", views.assign_anyway, name="assign-anyway"),
     path("proposals/<int:proposal_id>/decline/", views.decline, name="decline"),
     path("unassign/", views.unassign, name="unassign"),
+    path("suggestions/", views.suggestions, name="suggestions"),
+    path("suggestions/claim/", views.claim, name="claim"),
 ]

--- a/qb_site/console/views.py
+++ b/qb_site/console/views.py
@@ -31,6 +31,13 @@ from analyzer.services.assignment_proposal_validity import (
     queue_membership,
     resolve_on_queue_exit_policy,
 )
+from analyzer.services.assignment_suggestions import (
+    STATUS_NO_LABELS,
+    STATUS_NO_SNAPSHOT,
+    STATUS_NOT_A_REVIEWER,
+    format_skip_summary,
+    suggest_prs_for_reviewer,
+)
 from analyzer.services.reviewer_assignment import _opt_outs_for_prs
 from analyzer.services.reviewer_assignment_apply import assign_reviewer_and_record
 from analyzer.services.reviewer_assignment_engine import _normalize_login
@@ -309,6 +316,10 @@ def _build_home_context(reviewer) -> dict:
         "logout_url": reverse("console:logout"),
         "unassign_enabled": bool(getattr(settings, "ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED", False)),
         "prefs_url": reverse("console:prefs"),
+        # On-demand suggestions entry point (design doc 053) — shown in the header row and, because
+        # the empty state used to be a dead end, in the empty state too.
+        "suggestions_enabled": bool(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED", False)),
+        "suggestions_url": reverse("console:suggestions"),
     }
 
 
@@ -843,5 +854,197 @@ def unassign(request: HttpRequest) -> HttpResponse:
             "repo_label": f"{repo.owner}/{repo.name}",
             "unassigned": [{"number": n, "url": _pr_url(repo, n)} for n in unassigned],
             "failed": [{"number": n, "url": _pr_url(repo, n)} for n in failed],
+        },
+    )
+
+
+# --- on-demand suggestions (design doc 053) ------------------------------------
+
+# The claim re-check verifies *eligibility*, not membership in the rendered top-N: a PR the page
+# showed may drift past rank N by claim time and must still be claimable, so the re-run walks with
+# an effectively unbounded limit (the service walks the whole pool either way).
+_CLAIM_RECHECK_LIMIT = 100_000
+
+
+def _parse_labels_csv(raw: str | None) -> list[str]:
+    """Comma-separated label tokens from a query string or form field (service validates them)."""
+    if not raw:
+        return []
+    return [token.strip() for token in str(raw).split(",") if token.strip()]
+
+
+def _suggestion_group(repo, reviewer, *, labels: list[str]) -> dict:
+    """One repo's ``SuggestionResult`` flattened into template-ready display fields."""
+    result = suggest_prs_for_reviewer(repo, reviewer.github_login or "", labels=labels or None)
+    rows = []
+    for pr in result.suggestions:
+        matched = {label.lower() for label in pr.matched_labels}
+        rows.append(
+            {
+                "pr_number": pr.pr_number,
+                "title": pr.title,
+                "url": pr.url,
+                "author_login": pr.author_login,
+                "labels": [{"name": label, "matched": label.lower() in matched} for label in pr.topic_labels],
+                "queue_age": (format_compact_duration(int(pr.queue_age_seconds)) if pr.queue_age_seconds is not None else None),
+                "available_reviewer_count": pr.available_reviewer_count,
+                "load_weight": format_load_contribution(pr.load_weight),
+            }
+        )
+    return {
+        "repo_id": int(repo.id),
+        "repo_label": f"{repo.owner}/{repo.name}",
+        "result": result,
+        "rows": rows,
+        "load_line": format_load_line(result.load) if result.load is not None else None,
+        "skip_summary": format_skip_summary(result.skipped),
+        "no_snapshot": result.status == STATUS_NO_SNAPSHOT,
+        "no_labels": result.status == STATUS_NO_LABELS,
+        "not_a_reviewer": result.status == STATUS_NOT_A_REVIEWER,
+        "snapshot_generated_at": result.snapshot_generated_at,
+    }
+
+
+@require_GET
+def suggestions(request: HttpRequest) -> HttpResponse:
+    """Find PRs to review: render on-demand suggestions per repo (design doc 053).
+
+    Read-only. ``?repo=`` and ``?labels=`` pre-fill the request (the Zulip footer link carries
+    them) but are validated, never trusted: the repo must be one the reviewer has a preference in,
+    and the label set goes through the service's MAX_LABELS cap and unknown-label reporting. The
+    reviewer whose suggestions are computed is always the session reviewer.
+    """
+    reviewer, denied = _reviewer_from_session(request)
+    if denied is not None:
+        return denied
+    if reviewer is None:
+        return redirect(_login_url(reverse("console:suggestions")))
+
+    if not bool(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED", False)):
+        return render(
+            request, "console/unavailable.html", {"message": "Suggestions aren’t enabled yet — please check back later."}
+        )
+
+    repos = [
+        pref.repository
+        for pref in ReviewerPreference.objects.filter(user=reviewer)
+        .select_related("repository")
+        .order_by("repository__owner", "repository__name")
+    ]
+    repo_param = str(request.GET.get("repo") or "")
+    selected = next((r for r in repos if repo_param.isdigit() and int(r.id) == int(repo_param)), None)
+    labels = _parse_labels_csv(request.GET.get("labels"))
+
+    groups = [_suggestion_group(repo, reviewer, labels=labels) for repo in ([selected] if selected else repos)]
+    return render(
+        request,
+        "console/suggestions.html",
+        {
+            "reviewer": reviewer,
+            "groups": groups,
+            "labels_value": ", ".join(labels),
+            "filtered_repo": selected,
+            "claim_enabled": bool(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED", False)),
+            "home_url": reverse("console:home"),
+            "logout_url": reverse("console:logout"),
+            "suggestions_url": reverse("console:suggestions"),
+        },
+    )
+
+
+@require_POST
+def claim(request: HttpRequest) -> HttpResponse:
+    """Assign the signed-in reviewer to one or more suggested PRs (design doc 053).
+
+    Posts ``repo_id`` + ``pr_numbers`` (+ the ``labels`` override the offer was made under). Each
+    number is re-verified against a fresh suggestion run before any GitHub write (Invariant 6) —
+    without the re-check this endpoint degrades into a general self-assign API that bypasses
+    conflict-of-interest and opt-out rules — and the login assigned is always the session
+    reviewer's own, never taken from the request. Assignment goes through the 046 mutation path
+    (``assign_reviewer_and_record``: GitHub assign + audit row + per-PR sync). Partial failures
+    are contained and rendered as an assigned/failed split. There is no hold (Invariant 8): a
+    concurrent claim by someone else legally yields two assignees, so co-assignees are surfaced
+    rather than implying exclusivity.
+    """
+    reviewer, denied = _reviewer_from_session(request)
+    if denied is not None:
+        return denied
+    if reviewer is None:
+        return redirect(_login_url(reverse("console:suggestions")))
+
+    if not bool(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED", False)) or not bool(
+        getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED", False)
+    ):
+        return render(request, "console/unavailable.html", {"message": "Claiming isn’t enabled yet — please try again later."})
+
+    repo = Repository.objects.filter(id=request.POST.get("repo_id") or 0).only("id", "owner", "name").first()
+    if repo is None:
+        return render(request, "console/unavailable.html", {"message": "That repository was not found."}, status=404)
+
+    numbers: set[int] = set()
+    for raw in request.POST.getlist("pr_numbers"):
+        try:
+            numbers.add(int(raw))
+        except (TypeError, ValueError):
+            continue
+    if not numbers:
+        return redirect(reverse("console:suggestions"))
+
+    # Invariant 6: a fresh eligibility run over the same inputs — the only things that can make it
+    # disagree with the offer are real state changes (someone claimed it, an opt-out landed, ...).
+    labels = _parse_labels_csv(request.POST.get("labels"))
+    recheck = suggest_prs_for_reviewer(repo, reviewer.github_login or "", labels=labels or None, limit=_CLAIM_RECHECK_LIMIT)
+    eligible = {int(pr.pr_number) for pr in recheck.suggestions}
+
+    from core.services.github_operation_tokens import resolve_github_app_operation_token
+
+    token = resolve_github_app_operation_token(operation="assign_pr", owner=repo.owner, repo=repo.name)
+    if not token:
+        return render(request, "console/unavailable.html", {"message": "Assignment is temporarily unavailable. Try again later."})
+
+    now = timezone.now()
+    assigned: list[dict] = []
+    failed: list[dict] = []
+    for number in sorted(numbers):
+        if number not in eligible:
+            failed.append({"number": number, "url": _pr_url(repo, number), "reason": "no longer eligible"})
+            continue
+        outcome, _client, record = assign_reviewer_and_record(
+            repository=repo,
+            pr_number=number,
+            login=reviewer.github_login,
+            snapshot=None,  # an on-demand claim is not anchored to a nightly assignment snapshot
+            run_date=now.date(),
+            token=token,
+        )
+        # Same "did it actually land?" semantics as the accept handler (see _github_assign_self).
+        landed = outcome == "applied" or (
+            outcome == "already_recorded" and record is not None and record.status == ReviewerAssignmentApplication.STATUS_APPLIED
+        )
+        if landed:
+            assigned.append({"number": number, "url": _pr_url(repo, number), "co_assignees": []})
+        else:
+            failed.append({"number": number, "url": _pr_url(repo, number), "reason": "GitHub didn’t confirm the assignment"})
+
+    # Surface co-assignees on the claimed PRs (Invariant 8: no hold, no pretence of one). Best
+    # effort from our own PR rows; the enqueued sync converges them shortly after the claim.
+    if assigned:
+        assignees_by_number = {
+            int(pr.number): [str(login) for login in (pr.assignees or []) if login]
+            for pr in PullRequest.objects.filter(repository=repo, number__in=[row["number"] for row in assigned]).only(
+                "number", "assignees"
+            )
+        }
+        me = _normalize_login(reviewer.github_login)
+        for row in assigned:
+            row["co_assignees"] = [login for login in assignees_by_number.get(row["number"], []) if _normalize_login(login) != me]
+
+    return render(
+        request,
+        "console/claimed.html",
+        {
+            "repo_label": f"{repo.owner}/{repo.name}",
+            "assigned": assigned,
+            "failed": failed,
         },
     )

--- a/qb_site/console/views.py
+++ b/qb_site/console/views.py
@@ -441,6 +441,19 @@ def _pr_url(repository, number: int) -> str:
     return f"https://github.com/{repository.owner}/{repository.name}/pull/{int(number)}"
 
 
+def _repo_from_post(request: HttpRequest):
+    """``Repository`` named by the POSTed ``repo_id``, or ``None``.
+
+    The digit check is load-bearing, not defensive dressing: an ``id=`` lookup against a
+    non-numeric string raises ``ValueError`` inside the ORM, so a hand-rolled POST would 500
+    rather than reach the caller's not-found branch.
+    """
+    raw = str(request.POST.get("repo_id") or "").strip()
+    if not raw.isdigit():
+        return None
+    return Repository.objects.filter(id=int(raw)).only("id", "owner", "name").first()
+
+
 def _live_pr_for(proposal: AssignmentProposal) -> PullRequest | None:
     """Fetch the proposal's PR with just the fields the console needs to reason about it."""
     return (
@@ -806,7 +819,7 @@ def unassign(request: HttpRequest) -> HttpResponse:
     if not bool(getattr(settings, "ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED", False)):
         return render(request, "console/unavailable.html", {"message": "Unassigning isn’t enabled yet — please try again later."})
 
-    repo = Repository.objects.filter(id=request.POST.get("repo_id") or 0).only("id", "owner", "name").first()
+    repo = _repo_from_post(request)
     if repo is None:
         return render(request, "console/unavailable.html", {"message": "That repository was not found."}, status=404)
 
@@ -977,7 +990,7 @@ def claim(request: HttpRequest) -> HttpResponse:
     ):
         return render(request, "console/unavailable.html", {"message": "Claiming isn’t enabled yet — please try again later."})
 
-    repo = Repository.objects.filter(id=request.POST.get("repo_id") or 0).only("id", "owner", "name").first()
+    repo = _repo_from_post(request)
     if repo is None:
         return render(request, "console/unavailable.html", {"message": "That repository was not found."}, status=404)
 

--- a/qb_site/qb_site/settings/base.py
+++ b/qb_site/qb_site/settings/base.py
@@ -441,6 +441,21 @@ ANALYZER_ASSIGNMENT_PROPOSALS_DRY_RUN = env_bool(os.getenv("ANALYZER_ASSIGNMENT_
 ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED = env_bool(
     os.getenv("ANALYZER_ASSIGNMENT_PROPOSALS_CONSOLE_UNASSIGN_ENABLED"), False
 )
+# On-demand assignment suggestions (design doc 053): a reviewer asks "what should I review?"
+# from Zulip (`suggest-prs`) or the console suggestions page. Read-only compute; staged rollout
+# like 046/050 — everything defaults off.
+#   ENABLED               master switch for the read path on both surfaces.
+#   CONSOLE_CLAIM_ENABLED the console claim endpoint's GitHub write (assign via the 046 path).
+#   LIMIT                 service default suggestion count; what the console renders.
+#   ZULIP_LIMIT           surface override for the in-channel reply (console link carries the rest).
+#   MAX_LABELS            cap on the per-request label override set (form and query string alike).
+ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED = env_bool(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED"), False)
+ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED = env_bool(
+    os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED"), False
+)
+ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT", "10"))
+ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT", "5"))
+ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS", "5"))
 # Acceptance window: a proposal expires this many days after creation unless accepted. The
 # per-reviewer override in ReviewerPreference.notification_settings is clamped to >= 7.
 ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS = int(os.getenv("ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS", "7"))

--- a/qb_site/qb_site/settings/base.py
+++ b/qb_site/qb_site/settings/base.py
@@ -228,6 +228,10 @@ CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")
 # Use django-celery-results when explicitly configured via env; fallback to broker
 # so existing environments continue to work until .env is updated.
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+# Test-only: clears the Redis namespaces the suite shares with a running dev stack before the
+# suite starts. Lives in base rather than ci so a host run picks it up too — the run-to-run dedupe
+# leak it prevents does not care which settings module you used. Inert outside `manage.py test`.
+TEST_RUNNER = "qb_site.test_runner.IsolatedRedisDiscoverRunner"
 CELERY_RESULT_EXTENDED = env_bool(os.getenv("CELERY_RESULT_EXTENDED"), True)
 CELERY_TASK_TRACK_STARTED = env_bool(os.getenv("CELERY_TASK_TRACK_STARTED"), True)
 CELERY_TIMEZONE = TIME_ZONE

--- a/qb_site/qb_site/settings/base.py
+++ b/qb_site/qb_site/settings/base.py
@@ -456,6 +456,14 @@ ANALYZER_ASSIGNMENT_SUGGESTIONS_CONSOLE_CLAIM_ENABLED = env_bool(
 ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT", "10"))
 ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT", "5"))
 ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS = int(os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS", "5"))
+#   MAX_SNAPSHOT_AGE_SECONDS  refuse to answer from a snapshot older than this (0 disables). Guards
+#                             the `cache_key="default"` fallback taken when a repo has no active
+#                             rule set, where a long-dead snapshot row can otherwise be served as
+#                             live. Default 24h — far above the 5-minute refresh cadence, so a
+#                             normal snapshot outage does not take the feature down.
+ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS = int(
+    os.getenv("ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_SNAPSHOT_AGE_SECONDS", "86400")
+)
 # Acceptance window: a proposal expires this many days after creation unless accepted. The
 # per-reviewer override in ReviewerPreference.notification_settings is clamped to >= 7.
 ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS = int(os.getenv("ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS", "7"))

--- a/qb_site/qb_site/settings/ci.py
+++ b/qb_site/qb_site/settings/ci.py
@@ -17,6 +17,28 @@ ALLOWED_HOSTS = ["*"]
 
 # Use the default database configuration (PostgreSQL via env) for CI.
 
+# Give the suite its own Redis database index, so a test run cannot write into the keyspace a
+# developer's `docker compose up` stack is using. Paired with the runner below, which clears the
+# app's namespaces before the suite starts — that is what breaks the run-to-run leak, since the
+# test database restarts ids from 1 every run and would otherwise collide with the previous run's
+# `(repo_id, pr_number)` dedupe keys. Not a deployment knob; the env var is an escape hatch for a
+# Redis configured with fewer than 16 databases.
+CI_REDIS_DB_INDEX = int(os.getenv("CI_REDIS_DB_INDEX", "15"))
+
+
+def _with_redis_db_index(url: str, index: int) -> str:
+    """Repoint a redis:// or rediss:// URL at another database index, leaving anything else alone."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(str(url or ""))
+    if parts.scheme not in ("redis", "rediss"):
+        return url
+    return urlunsplit((parts.scheme, parts.netloc, f"/{int(index)}", parts.query, parts.fragment))
+
+
+CELERY_BROKER_URL = _with_redis_db_index(CELERY_BROKER_URL, CI_REDIS_DB_INDEX)  # noqa: F405
+CELERY_RESULT_BACKEND = _with_redis_db_index(CELERY_RESULT_BACKEND, CI_REDIS_DB_INDEX)  # noqa: F405
+
 # Ensure CI filtering is disabled unless a test overrides it explicitly
 SYNCER_CI_FILTER_MODE = "all"
 SYNCER_CI_ALLOW_CHECKRUN_NAMES = ""

--- a/qb_site/qb_site/test_runner.py
+++ b/qb_site/qb_site/test_runner.py
@@ -1,0 +1,80 @@
+"""Test runner that isolates the Redis state tests share with the running dev stack.
+
+``syncer.services.task_dedupe`` and ``syncer.services.rate_budget`` keep short-TTL keys in the
+Celery broker's Redis, keyed by ``(repo_id, pr_number)``. Django destroys and recreates the test
+database on every run, so those ids restart from 1 and collide with keys left behind by the
+*previous* run: ``sync_pr`` then returns ``runtime_deduped`` / ``recently_processed`` and every
+test that expected the task to do real work fails.
+
+That failure mode is unusually expensive to diagnose, which is why this runner exists rather than
+a note in a README. The symptoms actively mislead:
+
+* the failures land in suites that have nothing to do with dedupe (the backfill tests),
+* they appear only after a few consecutive runs, so the first run of a session is green,
+* each failing test passes when run on its own, which reads as flakiness rather than shared state,
+* and nothing in the diff is responsible, so the natural first suspicion is your own change.
+
+Two independent guards, because either alone leaves a gap:
+
+1. ``ci.py`` points the broker at its own Redis database index, so a test run cannot write into
+   the keyspace a developer's ``docker compose up`` stack is using.
+2. This runner clears the app's own namespaces before the suite starts, which is what actually
+   breaks the run-to-run chain (guard 1 alone still reuses one index across runs).
+
+Deliberately scan-and-delete over ``FLUSHDB``: it stays correct if someone runs the suite against
+a shared index anyway, and it can never destroy data this project did not write.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.test.runner import DiscoverRunner
+
+log = logging.getLogger(__name__)
+
+# Every prefix the app writes to the broker's Redis. Keep in sync with
+# `syncer.services.task_dedupe` and `syncer.services.rate_budget`; the guard test in
+# `qb_site/syncer/tests/test_redis_isolation.py` fails if a new prefix appears without being listed here.
+SHARED_REDIS_KEY_PATTERNS: tuple[str, ...] = (
+    "syncer:dedupe:*",
+    "gh:rate:*",
+    "gh:throttle:*",
+)
+
+
+def clear_shared_redis_state() -> int:
+    """Delete the app's Redis keys, returning how many were removed.
+
+    Never raises: Redis is optional for large parts of the suite, and a cleanup failure must not
+    be the reason a test run cannot start.
+    """
+    try:
+        from syncer.services.rate_budget import _get_redis_client
+
+        client = _get_redis_client()
+    except Exception:  # pragma: no cover - redis-py missing or broker misconfigured
+        return 0
+    if client is None:
+        return 0
+
+    removed = 0
+    try:
+        for pattern in SHARED_REDIS_KEY_PATTERNS:
+            keys = list(client.scan_iter(match=pattern, count=500))
+            if keys:
+                removed += int(client.delete(*keys) or 0)
+    except Exception as exc:  # pragma: no cover - unreachable broker
+        log.warning("test runner: could not clear shared Redis state (%s)", exc)
+        return removed
+    return removed
+
+
+class IsolatedRedisDiscoverRunner(DiscoverRunner):
+    """``DiscoverRunner`` that clears shared Redis state before the suite runs."""
+
+    def setup_test_environment(self, **kwargs) -> None:
+        super().setup_test_environment(**kwargs)
+        removed = clear_shared_redis_state()
+        if removed:
+            log.info("test runner: cleared %d leaked Redis key(s) before the suite", removed)

--- a/qb_site/syncer/tests/test_redis_isolation.py
+++ b/qb_site/syncer/tests/test_redis_isolation.py
@@ -1,0 +1,81 @@
+"""Guards for the shared-Redis test isolation (see `qb_site/qb_site/test_runner.py`).
+
+The bug these protect against: dedupe keys are `(repo_id, pr_number)`-scoped, the test database
+restarts ids from 1 on every run, so a second run collides with the first run's leftover keys and
+unrelated suites start failing. Nothing in the diff is responsible, which is what makes it costly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from django.test import TestCase
+
+from qb_site.test_runner import SHARED_REDIS_KEY_PATTERNS, clear_shared_redis_state
+from syncer.services.rate_budget import _get_redis_client
+from syncer.services.task_dedupe import TASK_ENQUEUE_DEDUPE_PREFIX, TASK_RUNTIME_DEDUPE_PREFIX
+
+# Modules allowed to write to the broker's Redis. A key literal appearing here must be covered by
+# SHARED_REDIS_KEY_PATTERNS, or the runner will leave it behind and the leak returns.
+_KEY_WRITING_MODULES = ("syncer/services/task_dedupe.py", "syncer/services/rate_budget.py")
+# "syncer:dedupe:runtime:", "gh:rate:snapshot", ... — a colon-separated lowercase literal.
+_KEY_LITERAL = re.compile(r'"([a-z][a-z0-9_]*(?::[a-z0-9_]+)+:?)"')
+
+
+def _pattern_covers(pattern: str, key: str) -> bool:
+    return re.fullmatch(re.escape(pattern).replace(r"\*", ".*"), key) is not None
+
+
+class TestSharedRedisKeyCoverage(TestCase):
+    """Every namespace the app writes must be one the runner clears."""
+
+    def test_declared_dedupe_prefixes_are_covered(self) -> None:
+        for prefix in (TASK_ENQUEUE_DEDUPE_PREFIX, TASK_RUNTIME_DEDUPE_PREFIX):
+            probe = f"{prefix}probe:1:2"
+            self.assertTrue(
+                any(_pattern_covers(p, probe) for p in SHARED_REDIS_KEY_PATTERNS),
+                f"{prefix!r} is not covered by SHARED_REDIS_KEY_PATTERNS",
+            )
+
+    def test_no_key_literal_escapes_the_patterns(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        uncovered: list[str] = []
+        for rel in _KEY_WRITING_MODULES:
+            for key in _KEY_LITERAL.findall((root / rel).read_text()):
+                probe = key if not key.endswith(":") else f"{key}probe"
+                if not any(_pattern_covers(p, probe) for p in SHARED_REDIS_KEY_PATTERNS):
+                    uncovered.append(f"{rel}: {key!r}")
+        self.assertEqual(
+            uncovered,
+            [],
+            "These Redis key literals are not cleared between test runs. Add a matching entry to "
+            "SHARED_REDIS_KEY_PATTERNS in qb_site/qb_site/test_runner.py:\n  " + "\n  ".join(uncovered),
+        )
+
+
+class TestClearSharedRedisState(TestCase):
+    """The clear itself works, and stays inside the app's own namespaces."""
+
+    def test_clears_app_keys_and_leaves_others_alone(self) -> None:
+        client = _get_redis_client()
+        if client is None:
+            self.skipTest("no Redis broker configured")
+        bystander = "someone-elses-key:test-redis-isolation"
+        client.set(f"{TASK_RUNTIME_DEDUPE_PREFIX}sync_pr:1:11", "1", ex=300)
+        client.set("gh:rate:snapshot", "1", ex=300)
+        client.set(bystander, "1", ex=300)
+        try:
+            removed = clear_shared_redis_state()
+            self.assertGreaterEqual(removed, 2)
+            self.assertIsNone(client.get(f"{TASK_RUNTIME_DEDUPE_PREFIX}sync_pr:1:11"))
+            self.assertIsNone(client.get("gh:rate:snapshot"))
+            # Scan-and-delete, never FLUSHDB: anything this project did not write must survive.
+            self.assertIsNotNone(client.get(bystander))
+        finally:
+            client.delete(bystander)
+
+    def test_is_safe_when_redis_is_unavailable(self) -> None:
+        # Cleanup failure must never be the reason a suite cannot start.
+        with self.settings(CELERY_BROKER_URL=""):
+            self.assertEqual(clear_shared_redis_state(), 0)

--- a/qb_site/syncer/tests/test_redis_isolation.py
+++ b/qb_site/syncer/tests/test_redis_isolation.py
@@ -55,12 +55,29 @@ class TestSharedRedisKeyCoverage(TestCase):
 
 
 class TestClearSharedRedisState(TestCase):
-    """The clear itself works, and stays inside the app's own namespaces."""
+    """The clear itself works, and stays inside the app's own namespaces.
 
-    def test_clears_app_keys_and_leaves_others_alone(self) -> None:
+    Skipped where Redis is unreachable, which includes `scripts/repo_check_compose.sh`: it starts
+    `web` against `db` only, so `redis:6379` does not resolve. That is also why the leak these
+    guards prevent never bit the canonical script — with no Redis, dedupe always fails open. It
+    bites the workflows that *do* have Redis up: a full `docker compose up`, or the focused
+    host-test loop in this directory's AGENTS.md.
+    """
+
+    def _reachable_client(self):
+        """Return a live Redis client, or skip. `_get_redis_client()` connects lazily, so it
+        returns an object even when nothing is listening — a `None` check alone is not enough."""
         client = _get_redis_client()
         if client is None:
             self.skipTest("no Redis broker configured")
+        try:
+            client.ping()
+        except Exception as exc:
+            self.skipTest(f"Redis broker not reachable ({exc})")
+        return client
+
+    def test_clears_app_keys_and_leaves_others_alone(self) -> None:
+        client = self._reachable_client()
         bystander = "someone-elses-key:test-redis-isolation"
         client.set(f"{TASK_RUNTIME_DEDUPE_PREFIX}sync_pr:1:11", "1", ex=300)
         client.set("gh:rate:snapshot", "1", ex=300)

--- a/qb_site/templates/console/claimed.html
+++ b/qb_site/templates/console/claimed.html
@@ -1,0 +1,34 @@
+{% extends "console/base.html" %}
+{% block title %}Assigned — Reviewer console{% endblock %}
+{% block body %}
+  <section class="hero">
+    <h1>Assigned</h1>
+  </section>
+  <section class="card">
+    {% if assigned %}
+      <div class="status status-ok" role="status">
+        Assigned you to {{ repo_label }}
+        {% for pr in assigned %}<a href="{{ pr.url }}">#{{ pr.number }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.
+      </div>
+      {% for pr in assigned %}
+        {% if pr.co_assignees %}
+          <p class="help"><a href="{{ pr.url }}">#{{ pr.number }}</a> is also assigned to {{ pr.co_assignees|join:", " }} — GitHub assignees are a set, so you share it.</p>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    {% if failed %}
+      <div class="status status-warn" role="alert">
+        Could not assign you to
+        {% for pr in failed %}<a href="{{ pr.url }}">#{{ pr.number }}</a> ({{ pr.reason }}){% if not forloop.last %}, {% endif %}{% endfor %}.
+        The suggestions page always reflects the current state.
+      </div>
+    {% endif %}
+    {% if not assigned and not failed %}
+      <p>Nothing was assigned.</p>
+    {% endif %}
+    <div class="actions">
+      <a class="cta" href="{% url 'console:home' %}">Back to the console</a>
+      <a class="cta cta-quiet" href="{% url 'console:suggestions' %}">More suggestions</a>
+    </div>
+  </section>
+{% endblock %}

--- a/qb_site/templates/console/home.html
+++ b/qb_site/templates/console/home.html
@@ -5,6 +5,7 @@
     <h1>Reviewer console</h1>
     <div class="meta signin-row">
       <span>Signed in as {{ reviewer.github_login }}.</span>
+      {% if suggestions_enabled %}<a href="{{ suggestions_url }}">Find PRs to review</a>{% endif %}
       <a href="{{ prefs_url }}">Reviewer preferences</a>
       <form class="inline" method="post" action="{{ logout_url }}">{% csrf_token %}<button class="linklike" type="submit">Sign out</button></form>
     </div>
@@ -78,6 +79,9 @@
   {% else %}
     <section class="card">
       <p class="empty">You have no proposals awaiting acceptance, and no PRs currently assigned to you.</p>
+      {% if suggestions_enabled %}
+        <p><a class="cta" href="{{ suggestions_url }}">Find PRs to review</a></p>
+      {% endif %}
     </section>
   {% endif %}
 {% endblock %}

--- a/qb_site/templates/console/suggestions.html
+++ b/qb_site/templates/console/suggestions.html
@@ -37,6 +37,11 @@
           {% for label in group.result.unknown_labels %}<span class="pr-label">{{ label }}</span>{% endfor %}
         </p>
       {% endif %}
+      {% if group.result.dropped_labels %}
+        <p class="help">Too many labels — these were not used:
+          {% for label in group.result.dropped_labels %}<span class="pr-label">{{ label }}</span>{% endfor %}
+        </p>
+      {% endif %}
 
       {% if group.no_snapshot %}
         <p class="empty">No queue snapshot is available for this repository right now — try again in a few minutes.</p>

--- a/qb_site/templates/console/suggestions.html
+++ b/qb_site/templates/console/suggestions.html
@@ -1,0 +1,86 @@
+{% extends "console/base.html" %}
+{% block title %}Find PRs to review — Reviewer console{% endblock %}
+{% block body %}
+  <section class="hero">
+    <h1>Find PRs to review</h1>
+    <div class="meta signin-row">
+      <span>Signed in as {{ reviewer.github_login }}.</span>
+      <a href="{{ home_url }}">Console home</a>
+      <form class="inline" method="post" action="{{ logout_url }}">{% csrf_token %}<button class="linklike" type="submit">Sign out</button></form>
+    </div>
+  </section>
+
+  {% if filtered_repo %}
+    <p class="help suggestions-scope">Showing {{ filtered_repo.owner }}/{{ filtered_repo.name }} only — <a href="{{ suggestions_url }}{% if labels_value %}?labels={{ labels_value|urlencode }}{% endif %}">show all repositories</a>.</p>
+  {% endif %}
+
+  {% for group in groups %}
+    <section class="card repo-card">
+      <h2 class="repo-name">{{ group.repo_label }}</h2>
+      {% if group.load_line %}
+        <details class="load-toggle">
+          <summary class="load-summary{% if group.result.load.at_capacity %} at-capacity{% endif %}">{{ group.load_line }}</summary>
+          {% include "console/_load_legend.html" %}
+        </details>
+      {% endif %}
+
+      <form class="label-override" method="get" action="{{ suggestions_url }}">
+        <input type="hidden" name="repo" value="{{ group.repo_id }}">
+        <label for="labels-{{ group.repo_id }}">Search other areas (comma-separated labels; replaces your stored areas for this search)</label>
+        <div class="label-override-row">
+          <input id="labels-{{ group.repo_id }}" type="text" name="labels" value="{{ labels_value }}" placeholder="e.g. t-algebra, t-topology">
+          <button class="cta cta-quiet" type="submit">Search</button>
+        </div>
+      </form>
+      {% if group.result.unknown_labels %}
+        <p class="help">Not topic labels in this repository (ignored):
+          {% for label in group.result.unknown_labels %}<span class="pr-label">{{ label }}</span>{% endfor %}
+        </p>
+      {% endif %}
+
+      {% if group.no_snapshot %}
+        <p class="empty">No queue snapshot is available for this repository right now — try again in a few minutes.</p>
+      {% elif group.not_a_reviewer %}
+        <p class="empty">You are not registered as a reviewer for this repository.</p>
+      {% elif group.no_labels %}
+        <p class="empty">You have no preferred labels here — enter labels above to search an area.</p>
+      {% elif group.rows %}
+        {% if claim_enabled %}
+          <form method="post" action="{% url 'console:claim' %}"
+                onsubmit="return confirm('Assign yourself to the selected PR(s)?');">
+            {% csrf_token %}
+            <input type="hidden" name="repo_id" value="{{ group.repo_id }}">
+            <input type="hidden" name="labels" value="{{ labels_value }}">
+        {% endif %}
+        <ul class="assigned suggestions">
+          {% for row in group.rows %}
+            <li class="assigned-row">
+              {% if claim_enabled %}<input class="assigned-check" type="checkbox" name="pr_numbers" value="{{ row.pr_number }}" aria-label="Select #{{ row.pr_number }}">{% endif %}
+              <a href="{{ row.url }}">#{{ row.pr_number }}</a> {{ row.title }}
+              <span class="pr-labels">{% for label in row.labels %}<span class="pr-label{% if label.matched %} matched{% endif %}">{{ label.name }}</span>{% endfor %}</span>
+              <span class="status">{% if row.queue_age %}on queue {{ row.queue_age }} · {% endif %}{{ row.available_reviewer_count }} available reviewer{{ row.available_reviewer_count|pluralize }}</span>
+              <span class="load-contrib" title="Load if claimed">{{ row.load_weight }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+        {% if claim_enabled %}
+            <div class="actions"><button class="btn-accept" type="submit">Assign me to selected</button></div>
+          </form>
+        {% else %}
+          <p class="help">Claiming from the console isn’t enabled yet — use <code>assign #NNN</code> in Zulip to take one.</p>
+        {% endif %}
+        {% if group.skip_summary %}<p class="help">Also considered and skipped: {{ group.skip_summary }}.</p>{% endif %}
+      {% else %}
+        <p class="empty">No eligible PRs right now{% if group.skip_summary %} — skipped: {{ group.skip_summary }}{% endif %}.</p>
+      {% endif %}
+
+      {% if group.snapshot_generated_at %}
+        <p class="help">From the queue snapshot of <time datetime="{{ group.snapshot_generated_at.isoformat }}">{{ group.snapshot_generated_at|date:"Y-m-d H:i" }} UTC</time>; the list refreshes as the snapshot does.</p>
+      {% endif %}
+    </section>
+  {% empty %}
+    <section class="card">
+      <p class="empty">You have no reviewer preferences configured, so there is nothing to suggest from. Register with the Zulip bot first.</p>
+    </section>
+  {% endfor %}
+{% endblock %}

--- a/qb_site/zulip_bot/AGENTS.md
+++ b/qb_site/zulip_bot/AGENTS.md
@@ -33,7 +33,8 @@ cd qb_site/zulip_bot/frontend && npm test
   `assign #NNN` hint, the snapshot timestamp (the reply is a permanent channel message; the console
   page is live), and a token-less console link carrying `?repo=&labels=` so "more suggestions" means
   more of the same question. Label tokens *replace* the sender's stored `preferred_labels` for the
-  request; unknown/non-topic labels are reported back. **In-place reply by design** (like `console`):
+  request; unknown/non-topic labels are reported back, as are labels refused by the `MAX_LABELS`
+  cap. **In-place reply by design** (like `console`):
   nothing is sensitive and the follow-up `assign` is in-place too. Gated by
   `ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED`; needs no mutation flag of its own (read-only — claiming
   reuses `assign`, which keeps its `ZULIP_ASSIGNMENT_MUTATIONS_ENABLED` + `ZULIP_COMMAND_POLICY`

--- a/qb_site/zulip_bot/AGENTS.md
+++ b/qb_site/zulip_bot/AGENTS.md
@@ -17,13 +17,27 @@ cd qb_site/zulip_bot/frontend && npm test
 ```
 
 ## Command Architecture Notes
-- Commands live in `commands/`: `assign`, `unassign`, `assigned-prs`, `pr-info`, `prefs`, `console`, `help`, `echo`, `register-test`, `close-pr`, `label-pr`.
+- Commands live in `commands/`: `assign`, `unassign`, `assigned-prs`, `suggest-prs` (aliases
+  `next-pr`, `suggest-pr`), `pr-info`, `prefs`, `console`, `help`, `echo`, `register-test`,
+  `close-pr`, `label-pr`.
 - **Command names are normalized** by `commands.normalize_command_name` (trim, lowercase, `_`→`-`) at
   registration, at parse time, and for `ZULIP_COMMAND_POLICY` keys — including in
   `manage.py zulip_policy` (`validate` accepts a legacy underscore key and rejects two spellings of one
   command; `sync` canonicalizes keys in place). Register hyphenated names; a name outside that space
   used to be silently undispatchable (`register_test` was, for exactly this reason).
 - `console`: replies in place with the stable, token-less reviewer console URL (`build_site_url(reverse("console:home"))`, design doc 050) where a reviewer accepts/declines assignment proposals. The link is non-secret and identical for everyone (the console self-authenticates via GitHub OAuth), so it is an in-place reply, not a proactive DM.
+- `suggest-prs [<owner/repo>] [<label> ...]`: on-demand assignment suggestions (design doc 053) —
+  "what should I review?". Renders `analyzer.services.assignment_suggestions.suggest_prs_for_reviewer`
+  (never re-derives eligibility): the honest load line, up to
+  `ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT` one-line PR entries, and a footer with the
+  `assign #NNN` hint, the snapshot timestamp (the reply is a permanent channel message; the console
+  page is live), and a token-less console link carrying `?repo=&labels=` so "more suggestions" means
+  more of the same question. Label tokens *replace* the sender's stored `preferred_labels` for the
+  request; unknown/non-topic labels are reported back. **In-place reply by design** (like `console`):
+  nothing is sensitive and the follow-up `assign` is in-place too. Gated by
+  `ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED`; needs no mutation flag of its own (read-only — claiming
+  reuses `assign`, which keeps its `ZULIP_ASSIGNMENT_MUTATIONS_ENABLED` + `ZULIP_COMMAND_POLICY`
+  gating; scope `suggest-prs` itself via `ZULIP_COMMAND_POLICY` like any other command if desired).
 - `pr-info`: parses GitHub PR links from Zulip `rendered_content`, reacts with 👀, then sends one message per PR (up to 10) with queue info sourced from `analyzer.services.pr_info`. Replies in the same conversation as the triggering message. Renders the acceptance-gate "Proposed to X (awaiting acceptance, expires …)" state (design doc 050) on its own line, distinct from Assignees.
 - Assignment command flow (all under `services/`) is split for clarity:
   - parse: `assignment_command_parser.py`,

--- a/qb_site/zulip_bot/commands/suggest_prs.py
+++ b/qb_site/zulip_bot/commands/suggest_prs.py
@@ -1,0 +1,160 @@
+"""``suggest-prs`` — reviewer-initiated "what should I review?" (design doc 053).
+
+Renders ``analyzer.services.assignment_suggestions`` output; eligibility is never re-derived here.
+Replies **in place** (like ``console``, unlike ``assigned-prs``): the content is not sensitive, and
+the natural next step — ``assign #12345`` — is itself an in-place command, so splitting one flow
+across a DM and a channel would be worse than either. The reply shows the shorter
+``ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT`` list; a token-less console link (with the request's
+repo and labels in the query string, so "more suggestions" means more of the *same* question)
+carries the rest. Claiming reuses the existing ``assign`` command — no new mutation surface.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.urls import reverse
+
+from analyzer.services.assignment_suggestions import (
+    STATUS_NO_LABELS,
+    STATUS_NO_SNAPSHOT,
+    STATUS_NOT_A_REVIEWER,
+    SuggestionResult,
+    format_skip_summary,
+    suggest_prs_for_reviewer,
+)
+from analyzer.services.reviewer_load import format_load_line
+from core.models import Repository, ReviewerPreference, User
+from core.services.site_urls import build_site_url
+from core.utils.zulip_time import format_global_time
+from zulip_bot.commands import CommandContext, CommandResult, register_command
+from zulip_bot.services.zulip_client import MAX_MESSAGE_CHARS, ZulipApiError, ZulipClient, split_message_chunks
+
+
+@register_command(
+    name="suggest-prs",
+    description="Suggest open PRs you could review. Syntax: suggest-prs [<owner/repo>] [<label> ...].",
+    aliases=("next-pr", "suggest-pr"),
+)
+def suggest_prs_command(context: CommandContext, args: str) -> CommandResult:
+    if not bool(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED", False)):
+        return CommandResult(content="On-demand suggestions are not enabled yet.")
+    if context.sender_id is None:
+        return CommandResult(content="Could not determine your Zulip identity from this message.")
+    user = User.objects.filter(zulip_user_id=context.sender_id).only("id", "github_login").first()
+    if user is None or not user.github_login:
+        return CommandResult(
+            content="No reviewer profile is linked to your Zulip account yet. Run `prefs` to start registration."
+        )
+
+    repo_arg, labels = _parse_args(args)
+    if repo_arg is not None:
+        owner, _, name = repo_arg.partition("/")
+        repo = Repository.objects.filter(owner__iexact=owner, name__iexact=name).first()
+        if repo is None:
+            return CommandResult(content=f"Unknown repository `{repo_arg}`.")
+        repos = [repo]
+    else:
+        repos = [
+            pref.repository
+            for pref in ReviewerPreference.objects.filter(user=user)
+            .select_related("repository")
+            .order_by("repository__owner", "repository__name")
+        ]
+        if not repos:
+            return CommandResult(content="You do not currently have any reviewer preferences configured.")
+
+    limit = int(getattr(settings, "ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT", 5))
+    sections = [
+        _render_repo_section(repo, user.github_login, labels=labels, limit=limit, show_heading=len(repos) > 1) for repo in repos
+    ]
+    content = "\n\n".join(sections)
+
+    # Belt-and-braces (the measured reply is far inside Zulip's cap): if the reply somehow exceeds
+    # one message, send the chunks proactively to the same conversation instead of truncating.
+    chunks = split_message_chunks(content=content, max_chars=MAX_MESSAGE_CHARS)
+    if len(chunks) == 1:
+        return CommandResult(content=content)
+    try:
+        client = ZulipClient()
+        for chunk in chunks:
+            if context.stream_id is not None and context.topic:
+                client.send_stream_message(stream=context.stream_id, topic=context.topic, content=chunk)
+            else:
+                client.send_direct_message(to=[context.sender_id], content=chunk)
+    except ZulipApiError as exc:
+        return CommandResult(content=f"Failed to send suggestions via Zulip API: {exc.message}")
+    return CommandResult(response_not_required=True)
+
+
+def _parse_args(args: str) -> tuple[str | None, list[str]]:
+    """Split ``[<owner/repo>] [<label> ...]``: a first token containing ``/`` is the repo."""
+    tokens = [token.strip().strip(",") for token in (args or "").split()]
+    tokens = [token for token in tokens if token]
+    repo_arg: str | None = None
+    if tokens and "/" in tokens[0]:
+        repo_arg = tokens[0]
+        tokens = tokens[1:]
+    return repo_arg, tokens
+
+
+def _console_more_url(result: SuggestionResult, labels: list[str]) -> str:
+    """Token-less console link carrying the request shape (repo + labels) in the query string.
+
+    No signed link is needed (cf. design doc 052): suggestions are reviewer-only, which is already
+    the console's admission rule, and the params only pre-fill the form — the login always comes
+    from the console session, never from the request.
+    """
+    params: dict[str, str] = {"repo": str(result.repository_id)}
+    if labels:
+        params["labels"] = ",".join(labels)
+    return f"{build_site_url(reverse('console:suggestions'))}?{urlencode(params)}"
+
+
+def _render_repo_section(repo: Repository, reviewer_login: str, *, labels: list[str], limit: int, show_heading: bool) -> str:
+    repo_label = f"{repo.owner}/{repo.name}"
+    result = suggest_prs_for_reviewer(repo, reviewer_login, labels=labels or None, limit=limit)
+
+    lines: list[str] = []
+    if show_heading:
+        lines.append(f"## {repo_label}")
+
+    if result.status == STATUS_NO_SNAPSHOT:
+        lines.append(f"No queue snapshot is available for {repo_label} right now — try again in a few minutes.")
+        return "\n".join(lines)
+    if result.status == STATUS_NOT_A_REVIEWER:
+        lines.append(f"You are not registered as a reviewer for {repo_label}.")
+        return "\n".join(lines)
+
+    if result.unknown_labels:
+        ignored = ", ".join(f"`{label}`" for label in result.unknown_labels)
+        lines.append(f"Ignored (not topic labels in {repo_label}): {ignored}.")
+    if result.status == STATUS_NO_LABELS:
+        lines.append(f"You have no preferred labels for {repo_label} — name some, e.g. `suggest-prs {repo_label} t-algebra`.")
+        return "\n".join(lines)
+
+    if result.load is not None:
+        lines.append(format_load_line(result.load))
+
+    if not result.suggestions:
+        summary = format_skip_summary(result.skipped)
+        tail = f" — skipped: {summary}" if summary else ""
+        lines.append(f"No eligible PRs right now{tail}.")
+        return "\n".join(lines)
+
+    for pr in result.suggestions:
+        label_str = " ".join(f"`{label}`" for label in pr.topic_labels)
+        line = f"- [#{pr.pr_number}]({pr.url}): {pr.title}"
+        if label_str:
+            line += f" — {label_str}"
+        lines.append(line)
+
+    # Footer. The wording stays indefinite ("more suggestions", never "the next N"): the prefix
+    # property only holds within one snapshot generation, and the snapshot refreshes.
+    footer_bits = [f"Take one with `assign #{result.suggestions[0].pr_number}`."]
+    footer_bits.append(f"[More suggestions on the console]({_console_more_url(result, labels)}).")
+    if result.snapshot_generated_at is not None:
+        footer_bits.append(f"Snapshot from {format_global_time(result.snapshot_generated_at)}.")
+    lines.append(" ".join(footer_bits))
+    return "\n".join(lines)

--- a/qb_site/zulip_bot/commands/suggest_prs.py
+++ b/qb_site/zulip_bot/commands/suggest_prs.py
@@ -130,6 +130,12 @@ def _render_repo_section(repo: Repository, reviewer_login: str, *, labels: list[
     if result.unknown_labels:
         ignored = ", ".join(f"`{label}`" for label in result.unknown_labels)
         lines.append(f"Ignored (not topic labels in {repo_label}): {ignored}.")
+    if result.dropped_labels:
+        # Distinct from the line above: these are perfectly good labels the per-request cap
+        # refused. Silently honouring a narrower request than the one asked for would make the
+        # result look like the reviewer's own labels were wrong.
+        dropped = ", ".join(f"`{label}`" for label in result.dropped_labels)
+        lines.append(f"Ignored (over the per-request label limit): {dropped}.")
     if result.status == STATUS_NO_LABELS:
         lines.append(f"You have no preferred labels for {repo_label} — name some, e.g. `suggest-prs {repo_label} t-algebra`.")
         return "\n".join(lines)

--- a/qb_site/zulip_bot/tests/commands/test_suggest_prs_command.py
+++ b/qb_site/zulip_bot/tests/commands/test_suggest_prs_command.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from analyzer.models import QueueSnapshot
+from core.models import Repository, ReviewerPreference, User
+from syncer.models import LabelDef
+from zulip_bot.commands import CommandContext, get_command
+from zulip_bot.commands.suggest_prs import suggest_prs_command
+
+
+def _pr_entry(*, author: str = "zed", labels: list[str], title: str = "a change", queue_age: float = 1000.0) -> dict:
+    return {
+        "author": author,
+        "title": title,
+        "labels": [{"name": name} for name in labels],
+        "assignees": [],
+        "pr_status": "AwaitingReview",
+        "total_queue_time": {"status": "valid", "value_td": queue_age},
+    }
+
+
+@override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED=True, QUEUEBOARD_BASE_URL="https://queue.example.org")
+class TestSuggestPrsCommand(TestCase):
+    def setUp(self) -> None:
+        self.repo = Repository.objects.create(owner="leanprover-community", name="mathlib4", default_branch="master")
+        self.now = timezone.now()
+        self.user = User.objects.create(github_login="bob", zulip_user_id=7001)
+        ReviewerPreference.objects.create(
+            repository=self.repo, user=self.user, preferred_labels=["t-analysis"], maximum_capacity=5
+        )
+        for name in ("t-analysis", "t-algebra"):
+            LabelDef.objects.create(repository=self.repo, name=name, color="ededed")
+
+    def _context(self, *, sender_id: int | None = 7001, content: str = "suggest-prs") -> CommandContext:
+        return CommandContext(
+            sender_id=sender_id,
+            sender_email="reviewer@example.com",
+            sender_full_name="Reviewer User",
+            message_content=content,
+            message_id=1,
+            stream_id=42,
+            topic="queue",
+            is_private=False,
+            allowed_command_names=frozenset({"suggest-prs"}),
+        )
+
+    def _seed_snapshot(self, prs: dict[str, dict]) -> None:
+        QueueSnapshot.objects.create(
+            repository=self.repo,
+            cache_key="default",  # no QueueRuleSet in these tests
+            generated_at=self.now,
+            payload={
+                "meta": {"generated_at": self.now.isoformat()},
+                "prs": prs,
+                "lists": {"dashboards": {"Queue": [int(n) for n in prs]}},
+            },
+            etag="etag",
+            pr_count=len(prs),
+            queue_count=len(prs),
+        )
+
+    # ---- registry / gating -------------------------------------------------
+
+    def test_aliases_dispatch_to_the_same_command(self) -> None:
+        canonical = get_command("suggest-prs")
+        self.assertIsNotNone(canonical)
+        self.assertIs(get_command("next-pr"), canonical)
+        self.assertIs(get_command("suggest-pr"), canonical)
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_ENABLED=False)
+    def test_flag_gated(self) -> None:
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("not enabled", result.content)
+
+    def test_unlinked_sender(self) -> None:
+        result = suggest_prs_command(self._context(sender_id=9999), "")
+        self.assertIn("No reviewer profile", result.content)
+
+    # ---- rendering -----------------------------------------------------------
+
+    def test_replies_in_place_with_load_line_and_pr_lines(self) -> None:
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"], title="analysis PR")})
+        result = suggest_prs_command(self._context(), "")
+        self.assertFalse(result.response_not_required)  # in-place reply, not a proactive DM
+        self.assertIn("Load: 0 / 5 (5 free)", result.content)
+        self.assertIn("[#101](https://github.com/leanprover-community/mathlib4/pull/101): analysis PR", result.content)
+        self.assertIn("`t-analysis`", result.content)
+
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_ZULIP_LIMIT=2)
+    def test_zulip_limit_caps_the_list(self) -> None:
+        self._seed_snapshot(
+            {
+                "101": _pr_entry(labels=["t-analysis"], queue_age=3000.0),
+                "102": _pr_entry(labels=["t-analysis"], queue_age=2000.0),
+                "103": _pr_entry(labels=["t-analysis"], queue_age=1000.0),
+            }
+        )
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("#101", result.content)
+        self.assertIn("#102", result.content)
+        self.assertNotIn("#103", result.content)
+
+    def test_footer_contents(self) -> None:
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("`assign #101`", result.content)
+        self.assertIn(
+            f"https://queue.example.org/console/suggestions/?repo={self.repo.id}",
+            result.content,
+        )
+        self.assertIn("<time:", result.content)
+        # Indefinite wording: never a promise the snapshot refresh can break.
+        self.assertIn("More suggestions", result.content)
+        self.assertNotIn("next 5", result.content)
+
+    def test_footer_console_link_carries_the_requested_labels(self) -> None:
+        self._seed_snapshot({"102": _pr_entry(labels=["t-algebra"], title="algebra PR")})
+        result = suggest_prs_command(self._context(), "t-algebra")
+        self.assertIn("algebra PR", result.content)
+        self.assertIn(f"?repo={self.repo.id}&labels=t-algebra", result.content)
+
+    def test_empty_result_renders_the_skip_tally(self) -> None:
+        self._seed_snapshot({"102": _pr_entry(labels=["t-algebra"])})
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("No eligible PRs right now", result.content)
+        self.assertIn("1 not matching your labels", result.content)
+
+    def test_unknown_labels_reported(self) -> None:
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "t-typo t-analysis")
+        self.assertIn("Ignored (not topic labels", result.content)
+        self.assertIn("`t-typo`", result.content)
+        self.assertIn("#101", result.content)
+
+    def test_no_preferred_labels_hints_at_the_label_override(self) -> None:
+        pref = ReviewerPreference.objects.get(user=self.user)
+        pref.preferred_labels = []
+        pref.save(update_fields=["preferred_labels"])
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("no preferred labels", result.content)
+        self.assertIn("suggest-prs leanprover-community/mathlib4 t-algebra", result.content)
+
+    def test_no_snapshot_message(self) -> None:
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("No queue snapshot is available", result.content)
+
+    # ---- repo argument -------------------------------------------------------
+
+    def test_repo_argument_scopes_the_request(self) -> None:
+        other = Repository.objects.create(owner="other", name="repo", default_branch="main")
+        ReviewerPreference.objects.create(repository=other, user=self.user, preferred_labels=["t-analysis"])
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "leanprover-community/mathlib4")
+        self.assertIn("#101", result.content)
+        self.assertNotIn("other/repo", result.content)
+
+    def test_unknown_repo_argument(self) -> None:
+        result = suggest_prs_command(self._context(), "nobody/nowhere")
+        self.assertIn("Unknown repository `nobody/nowhere`", result.content)
+
+    def test_sections_per_repo_when_no_repo_argument(self) -> None:
+        other = Repository.objects.create(owner="other", name="repo", default_branch="main")
+        ReviewerPreference.objects.create(repository=other, user=self.user, preferred_labels=["t-analysis"])
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "")
+        self.assertIn("## leanprover-community/mathlib4", result.content)
+        self.assertIn("## other/repo", result.content)
+        self.assertIn("No queue snapshot is available for other/repo", result.content)

--- a/qb_site/zulip_bot/tests/commands/test_suggest_prs_command.py
+++ b/qb_site/zulip_bot/tests/commands/test_suggest_prs_command.py
@@ -134,6 +134,13 @@ class TestSuggestPrsCommand(TestCase):
         self.assertIn("`t-typo`", result.content)
         self.assertIn("#101", result.content)
 
+    @override_settings(ANALYZER_ASSIGNMENT_SUGGESTIONS_MAX_LABELS=1)
+    def test_labels_over_the_cap_are_reported_not_silently_ignored(self) -> None:
+        self._seed_snapshot({"101": _pr_entry(labels=["t-analysis"])})
+        result = suggest_prs_command(self._context(), "t-analysis t-algebra")
+        self.assertIn("over the per-request label limit", result.content)
+        self.assertIn("`t-algebra`", result.content)
+
     def test_no_preferred_labels_hints_at_the_label_override(self) -> None:
         pref = ReviewerPreference.objects.get(user=self.user)
         pref.preferred_labels = []

--- a/qb_site/zulip_bot/views.py
+++ b/qb_site/zulip_bot/views.py
@@ -24,6 +24,7 @@ from zulip_bot.commands import help as _help  # noqa: F401
 from zulip_bot.commands import label_pr as _label_pr  # noqa: F401
 from zulip_bot.commands import prefs as _prefs  # noqa: F401
 from zulip_bot.commands import register_test as _register_test  # noqa: F401
+from zulip_bot.commands import suggest_prs as _suggest_prs  # noqa: F401
 from zulip_bot.commands import pr_info as _pr_info  # noqa: F401
 from zulip_bot.commands import unassign as _unassign  # noqa: F401
 from zulip_bot.services.registration_bootstrap import ensure_default_preferences_for_user

--- a/scripts/probe_053_payload_cost.py
+++ b/scripts/probe_053_payload_cost.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+"""Measure the queue-snapshot payload load cost on the suggestion request path (design doc 053).
+
+The 053 baseline left one number unmeasured: what it costs to get the ~12.8 MB ``QueueSnapshot``
+payload out of Postgres and into a Python dict. The original probe timed attribute access on an
+already-materialized ``JSONField`` and therefore measured nothing. This script times *queryset
+evaluation* and decomposes it:
+
+- **fetch**   Postgres read + TOAST decompress + wire transfer, measured as ``payload::text``
+- **parse**   ``json.loads`` on that text, in Python
+- **orm**     the real ``QueueSnapshot.objects...first()`` path both surfaces would use
+- **request** the whole suggestion request: payload + assignment inputs + load line + rank + walk
+
+It also measures **memory**, which on a small dyno may matter more than latency: a 12.8 MB JSON
+document becomes a far larger graph of Python dicts, strings and lists, and every concurrent
+console request holds its own copy.
+
+Strictly read-only: SELECTs only, no writes, no GitHub calls, no snapshot builds.
+
+Emits one JSON object on stdout between BEGIN/END markers.
+
+Usage on the dyno:
+    PYTHONPATH=$PWD/qb_site:$PWD python probe_053_payload_cost.py [--repeats 5] [--repo owner/name]
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import resource
+import sys
+import time
+import tracemalloc
+from datetime import datetime, timezone
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "qb_site.settings.production")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db import connection  # noqa: E402
+
+from analyzer.models import QueueSnapshot  # noqa: E402
+from analyzer.services.queue_rules import default_rule_set_for_repo  # noqa: E402
+from analyzer.services.reviewer_assignment import _prepare_assignment_inputs  # noqa: E402
+from analyzer.services.reviewer_assignment_engine import rank_prs_for_assignment  # noqa: E402
+from analyzer.services.reviewer_assignment_engine import suggest_reviewer_for_pr_with_trace  # noqa: E402
+from analyzer.services.reviewer_load import reviewer_load_for  # noqa: E402
+from core.models import Repository, ReviewerPreference  # noqa: E402
+from core.services.topic_labels import topic_label_matcher_for_repo  # noqa: E402
+
+MARK_BEGIN = "===QB-PAYLOAD-COST-JSON-BEGIN==="
+MARK_END = "===QB-PAYLOAD-COST-JSON-END==="
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def stats(samples: list[float]) -> dict:
+    """Timing summary in milliseconds. `first` is reported separately: it carries cold-cache cost."""
+    if not samples:
+        return {}
+    ordered = sorted(samples)
+    return {
+        "n": len(samples),
+        "first_ms": round(samples[0] * 1000, 1),
+        "min_ms": round(ordered[0] * 1000, 1),
+        "median_ms": round(ordered[len(ordered) // 2] * 1000, 1),
+        "max_ms": round(ordered[-1] * 1000, 1),
+    }
+
+
+def rss_bytes() -> int | None:
+    """Current resident set size, from /proc (Linux dynos). None where unavailable."""
+    try:
+        with open("/proc/self/status", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return None
+
+
+def peak_rss_bytes() -> int:
+    """Peak RSS for the process. ru_maxrss is KiB on Linux, bytes on macOS."""
+    raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return raw * 1024 if sys.platform.startswith("linux") else raw
+
+
+# Big objects are released by rebinding the name to None at the call site and then collecting.
+# This has to be inline: `locals()` is a snapshot for function scopes, so a helper that assigns
+# into it frees nothing. It matters because a 12.8 MB payload expands to a much larger Python
+# graph, and holding the previous iteration's copy while the next query materialises would double
+# peak memory on a small dyno.
+
+
+def measure_repo(repository: Repository, *, repeats: int) -> dict:
+    out: dict = {"repository": f"{repository.owner}/{repository.name}"}
+
+    rule_set = default_rule_set_for_repo(repository)
+    cache_key = str(rule_set.id) if rule_set else "default"
+    out["cache_key"] = cache_key
+
+    row = (
+        QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key)
+        .order_by("-generated_at")
+        .only("id", "generated_at", "pr_count", "queue_count")
+        .first()
+    )
+    if row is None:
+        out["status"] = "no_snapshot"
+        return out
+    snapshot_id = row.id
+    out["snapshot"] = {
+        "id": snapshot_id,
+        "generated_at": row.generated_at.isoformat(),
+        "pr_count": row.pr_count,
+        "queue_count": row.queue_count,
+    }
+
+    # --- sizes, straight from Postgres ---------------------------------------------------------
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT pg_column_size(payload), octet_length(payload::text) FROM analyzer_queuesnapshot WHERE id = %s",
+            [snapshot_id],
+        )
+        on_disk, as_text = cur.fetchone()
+    out["size"] = {
+        "toast_compressed_bytes": int(on_disk),
+        "json_text_bytes": int(as_text),
+        "toast_compressed_mb": round(int(on_disk) / 1_000_000, 2),
+        "json_text_mb": round(int(as_text) / 1_000_000, 2),
+        "compression_ratio": round(int(as_text) / int(on_disk), 2),
+    }
+
+    # --- A. fetch: Postgres read + decompress + wire, no Python JSON parsing -------------------
+    fetch_samples: list[float] = []
+    for _ in range(repeats):
+        with connection.cursor() as cur:
+            t0 = time.perf_counter()
+            cur.execute("SELECT payload::text FROM analyzer_queuesnapshot WHERE id = %s", [snapshot_id])
+            text = cur.fetchone()[0]
+            fetch_samples.append(time.perf_counter() - t0)
+        last_text = text
+    out["fetch_as_text"] = stats(fetch_samples)
+
+    # --- B. parse: json.loads on the text we already have --------------------------------------
+    parse_samples: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        parsed = json.loads(last_text)
+        parse_samples.append(time.perf_counter() - t0)
+        del parsed
+        gc.collect()
+    out["json_parse"] = stats(parse_samples)
+    last_text = text = None
+    gc.collect()
+
+    # --- C. the real ORM path both surfaces would use ------------------------------------------
+    orm_samples: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        obj = (
+            QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key)
+            .order_by("-generated_at")
+            .only("payload")
+            .first()
+        )
+        payload = obj.payload
+        n_prs = len(payload.get("prs", {}))
+        orm_samples.append(time.perf_counter() - t0)
+        obj = payload = None
+        gc.collect()
+    out["orm_only_payload"] = stats(orm_samples)
+    out["orm_prs_seen"] = n_prs
+
+    # --- D. same, without .only() — does fetching the other columns matter? --------------------
+    full_samples: list[float] = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        obj = QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key).order_by("-generated_at").first()
+        _ = obj.payload.get("prs", {})
+        full_samples.append(time.perf_counter() - t0)
+        obj = None
+        gc.collect()
+    out["orm_full_row"] = stats(full_samples)
+
+    # --- E. memory: what one held payload costs ------------------------------------------------
+    gc.collect()
+    rss_before = rss_bytes()
+    tracemalloc.start()
+    obj = (
+        QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key).order_by("-generated_at").only("payload").first()
+    )
+    payload = obj.payload
+    traced_current, traced_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    rss_after = rss_bytes()
+    out["memory"] = {
+        "traced_current_bytes": traced_current,
+        "traced_current_mb": round(traced_current / 1_000_000, 1),
+        "traced_peak_mb": round(traced_peak / 1_000_000, 1),
+        "rss_before_mb": round(rss_before / 1_000_000, 1) if rss_before else None,
+        "rss_after_mb": round(rss_after / 1_000_000, 1) if rss_after else None,
+        "rss_delta_mb": round((rss_after - rss_before) / 1_000_000, 1) if rss_before and rss_after else None,
+        "expansion_vs_json_text": round(traced_current / int(as_text), 2),
+        "note": "traced_current is the live Python object graph for one held payload",
+    }
+    obj = payload = None
+    gc.collect()
+
+    # --- F. end-to-end: the whole suggestion request -------------------------------------------
+    reviewer = (
+        ReviewerPreference.objects.filter(repository=repository)
+        .select_related("user")
+        .exclude(user__github_login=None)
+        .order_by("user__github_login")
+        .first()
+    )
+    if reviewer is not None:
+        matcher = topic_label_matcher_for_repo(repository)
+        login = reviewer.user.github_login
+        request_samples: list[float] = []
+        phase_totals = {"payload": 0.0, "inputs": 0.0, "load": 0.0, "rank": 0.0, "walk": 0.0}
+        for _ in range(repeats):
+            now = datetime.now(timezone.utc)
+            t_start = time.perf_counter()
+
+            t0 = time.perf_counter()
+            obj = (
+                QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key)
+                .order_by("-generated_at")
+                .only("payload")
+                .first()
+            )
+            payload_e2e = obj.payload
+            phase_totals["payload"] += time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            inputs = _prepare_assignment_inputs(repository, payload=payload_e2e, now=now, rule_set=rule_set)
+            phase_totals["inputs"] += time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            reviewer_load_for(repository, login, snapshot_payload=payload_e2e, now=now)
+            phase_totals["load"] += time.perf_counter() - t0
+
+            all_prs = payload_e2e.get("prs", {})
+            t0 = time.perf_counter()
+            ranked, _trace = rank_prs_for_assignment(
+                prs_to_assign=inputs.assignable_queue_prs,
+                all_prs=all_prs,
+                reviewers=inputs.reviewers,
+                assignment_stats=inputs.assignments,
+                excluded_by_pr=inputs.excluded_by_pr,
+                topic_label_matcher=matcher,
+            )
+            phase_totals["rank"] += time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            for pr_number in ranked:
+                suggest_reviewer_for_pr_with_trace(
+                    pr_entry=all_prs.get(pr_number) or all_prs.get(str(pr_number)) or {},
+                    reviewers=inputs.reviewers,
+                    assignment_stats=inputs.assignments,
+                    excluded_logins=inputs.excluded_by_pr.get(pr_number, set()),
+                    topic_label_matcher=matcher,
+                )
+            phase_totals["walk"] += time.perf_counter() - t0
+
+            request_samples.append(time.perf_counter() - t_start)
+            obj = payload_e2e = inputs = ranked = all_prs = None
+            gc.collect()
+
+        out["end_to_end_request"] = stats(request_samples)
+        out["end_to_end_phases_mean_ms"] = {k: round(v / repeats * 1000, 1) for k, v in phase_totals.items()}
+        out["end_to_end_note"] = (
+            "one representative reviewer; walk is the full pool with no early stop at `limit`, i.e. the worst case"
+        )
+
+    out["peak_rss_mb"] = round(peak_rss_bytes() / 1_000_000, 1)
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--repo", default=None, help="restrict to owner/name")
+    args = parser.parse_args()
+
+    # Warm the connection so setup cost does not land in the first sample.
+    with connection.cursor() as cur:
+        cur.execute("SELECT 1")
+
+    repos = Repository.objects.all().order_by("id")
+    if args.repo:
+        owner, _, name = args.repo.partition("/")
+        repos = repos.filter(owner=owner, name=name)
+
+    result = {
+        "probe": "design-doc-053-payload-cost",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repeats": args.repeats,
+        "python": sys.version.split()[0],
+        "dyno": os.getenv("DYNO", ""),
+        "repositories": [],
+    }
+    for repo in repos:
+        if not QueueSnapshot.objects.filter(repository=repo).exists():
+            continue
+        log(f"measuring {repo.owner}/{repo.name} ...")
+        try:
+            result["repositories"].append(measure_repo(repo, repeats=args.repeats))
+        except Exception as exc:  # noqa: BLE001 - a probe should report, not crash the run
+            result["repositories"].append({"repository": f"{repo.owner}/{repo.name}", "error": f"{type(exc).__name__}: {exc}"})
+            log(f"  failed: {type(exc).__name__}: {exc}")
+
+    print(MARK_BEGIN)
+    print(json.dumps(result, indent=2, default=str))
+    print(MARK_END)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_053_payload_cost.py
+++ b/scripts/probe_053_payload_cost.py
@@ -45,7 +45,16 @@ from django.db import connection  # noqa: E402
 
 from analyzer.models import QueueSnapshot  # noqa: E402
 from analyzer.services.queue_rules import default_rule_set_for_repo  # noqa: E402
-from analyzer.services.reviewer_assignment import prepare_assignment_inputs  # noqa: E402
+
+# The pool assembler was private (`_prepare_assignment_inputs`) until design doc 053 promoted it.
+# Accept either name: this probe measures the *pre-deploy* baseline, so it has to run against a
+# revision that predates the rename — a baseline probe that only runs post-deploy is useless.
+try:
+    from analyzer.services.reviewer_assignment import prepare_assignment_inputs  # noqa: E402
+except ImportError:  # deployed revision predates the 053 rename
+    from analyzer.services.reviewer_assignment import (  # noqa: E402
+        _prepare_assignment_inputs as prepare_assignment_inputs,
+    )
 from analyzer.services.reviewer_assignment_engine import rank_prs_for_assignment  # noqa: E402
 from analyzer.services.reviewer_assignment_engine import suggest_reviewer_for_pr_with_trace  # noqa: E402
 from analyzer.services.reviewer_load import reviewer_load_for  # noqa: E402

--- a/scripts/probe_053_payload_cost.py
+++ b/scripts/probe_053_payload_cost.py
@@ -45,7 +45,7 @@ from django.db import connection  # noqa: E402
 
 from analyzer.models import QueueSnapshot  # noqa: E402
 from analyzer.services.queue_rules import default_rule_set_for_repo  # noqa: E402
-from analyzer.services.reviewer_assignment import _prepare_assignment_inputs  # noqa: E402
+from analyzer.services.reviewer_assignment import prepare_assignment_inputs  # noqa: E402
 from analyzer.services.reviewer_assignment_engine import rank_prs_for_assignment  # noqa: E402
 from analyzer.services.reviewer_assignment_engine import suggest_reviewer_for_pr_with_trace  # noqa: E402
 from analyzer.services.reviewer_load import reviewer_load_for  # noqa: E402
@@ -242,7 +242,7 @@ def measure_repo(repository: Repository, *, repeats: int) -> dict:
             phase_totals["payload"] += time.perf_counter() - t0
 
             t0 = time.perf_counter()
-            inputs = _prepare_assignment_inputs(repository, payload=payload_e2e, now=now, rule_set=rule_set)
+            inputs = prepare_assignment_inputs(repository, payload=payload_e2e, now=now, rule_set=rule_set)
             phase_totals["inputs"] += time.perf_counter() - t0
 
             t0 = time.perf_counter()

--- a/scripts/probe_053_precheck.sql
+++ b/scripts/probe_053_precheck.sql
@@ -1,0 +1,100 @@
+-- Design doc 053 pre-check: is there anything to suggest, and is push-based assignment landing?
+-- Read-only. Run with:  heroku pg:psql -a <APP> -f scripts/probe_053_precheck.sql
+\pset pager off
+\echo '=== 1. queue size / snapshot freshness ==='
+SELECT r.owner || '/' || r.name AS repo,
+       q.cache_key,
+       q.pr_count,
+       q.queue_count,
+       q.generated_at,
+       round(extract(epoch FROM (now() - q.generated_at)) / 3600.0, 1) AS age_hours,
+       pg_size_pretty(pg_column_size(q.payload)::bigint) AS payload_size
+FROM analyzer_queuesnapshot q
+JOIN core_repository r ON r.id = q.repository_id
+ORDER BY q.generated_at DESC;
+
+\echo ''
+\echo '=== 2. what the nightly engine last placed (assignment_count) vs the queue ==='
+SELECT r.owner || '/' || r.name AS repo,
+       s.cache_key,
+       s.assignment_count,
+       s.generated_at,
+       round(extract(epoch FROM (now() - s.generated_at)) / 3600.0, 1) AS age_hours
+FROM analyzer_reviewerassignmentsnapshot s
+JOIN core_repository r ON r.id = s.repository_id
+ORDER BY s.generated_at DESC;
+
+\echo ''
+\echo '=== 3. reviewer population (the supply side) ==='
+SELECT r.owner || '/' || r.name AS repo,
+       count(*) AS prefs,
+       count(*) FILTER (WHERE u.github_login IS NOT NULL AND u.github_login <> '') AS with_login,
+       count(*) FILTER (WHERE NOT p.auto_assign) AS auto_assign_off,
+       count(*) FILTER (WHERE p.away_until IS NOT NULL AND p.away_until > now()) AS away_now,
+       count(*) FILTER (WHERE jsonb_array_length(p.preferred_labels) = 0) AS no_preferred_labels,
+       count(*) FILTER (WHERE jsonb_array_length(p.conflict_of_interest) > 0) AS with_conflicts,
+       count(*) FILTER (WHERE u.zulip_user_id IS NOT NULL) AS zulip_linked,
+       round(avg(p.maximum_capacity), 1) AS avg_capacity,
+       round(avg(jsonb_array_length(p.preferred_labels)), 1) AS avg_labels,
+       min(jsonb_array_length(p.preferred_labels)) AS min_labels,
+       max(jsonb_array_length(p.preferred_labels)) AS max_labels
+FROM core_reviewerpreference p
+JOIN core_repository r ON r.id = p.repository_id
+LEFT JOIN core_user u ON u.id = p.user_id
+GROUP BY 1
+ORDER BY 1;
+
+\echo ''
+\echo '=== 4. acceptance mode mix ==='
+SELECT r.owner || '/' || r.name AS repo, p.assignment_acceptance, count(*)
+FROM core_reviewerpreference p
+JOIN core_repository r ON r.id = p.repository_id
+GROUP BY 1, 2 ORDER BY 1, 3 DESC;
+
+\echo ''
+\echo '=== 5. label demand: how many reviewers claim each preferred label ==='
+SELECT lower(lab.value #>> '{}') AS label, count(*) AS reviewers
+FROM core_reviewerpreference p, jsonb_array_elements(p.preferred_labels) AS lab
+GROUP BY 1 ORDER BY 2 DESC, 1 LIMIT 60;
+
+\echo ''
+\echo '=== 6. proposal lifecycle: does push-based assignment get accepted? ==='
+SELECT state,
+       count(*) AS all_time,
+       count(*) FILTER (WHERE created_at > now() - interval '30 days') AS last_30d,
+       count(*) FILTER (WHERE created_at > now() - interval '7 days') AS last_7d
+FROM analyzer_assignmentproposal
+GROUP BY 1 ORDER BY 2 DESC;
+
+\echo ''
+\echo '=== 6b. time-to-decision for decided proposals ==='
+SELECT state,
+       count(*) AS n,
+       round(avg(extract(epoch FROM (decided_at - created_at)) / 3600.0)::numeric, 1) AS avg_hours,
+       round(max(extract(epoch FROM (decided_at - created_at)) / 3600.0)::numeric, 1) AS max_hours
+FROM analyzer_assignmentproposal
+WHERE decided_at IS NOT NULL
+GROUP BY 1 ORDER BY 2 DESC;
+
+\echo ''
+\echo '=== 7. assignment applications actually written ==='
+SELECT status,
+       count(*) AS all_time,
+       count(*) FILTER (WHERE run_date > current_date - 30) AS last_30d,
+       count(DISTINCT run_date) FILTER (WHERE run_date > current_date - 30) AS run_days_30d
+FROM analyzer_reviewerassignmentapplication
+GROUP BY 1 ORDER BY 2 DESC;
+
+\echo ''
+\echo '=== 7b. per-day application volume, last 21 days ==='
+SELECT run_date, count(*) AS applications, count(DISTINCT reviewer_login) AS reviewers
+FROM analyzer_reviewerassignmentapplication
+WHERE run_date > current_date - 21
+GROUP BY 1 ORDER BY 1 DESC;
+
+\echo ''
+\echo '=== 8. opt-outs (a proxy for "the push picked wrong") ==='
+SELECT count(*) FILTER (WHERE active) AS active_opt_outs,
+       count(*) AS all_time,
+       count(*) FILTER (WHERE opted_out_at > now() - interval '30 days') AS last_30d
+FROM analyzer_revieweroptout;

--- a/scripts/probe_053_suggestions.py
+++ b/scripts/probe_053_suggestions.py
@@ -53,9 +53,18 @@ from analyzer.services.reviewer_assignment import (  # noqa: E402
     _filter_assignment_forbidden_prs,
     _filter_prs_without_active_assignee,
     _filter_prs_without_active_proposal,
-    prepare_assignment_inputs,
     build_reviewer_catalog,
 )
+
+# The pool assembler was private (`_prepare_assignment_inputs`) until design doc 053 promoted it.
+# Accept either name: this probe measures the *pre-deploy* baseline, so it has to run against a
+# revision that predates the rename — a baseline probe that only runs post-deploy is useless.
+try:
+    from analyzer.services.reviewer_assignment import prepare_assignment_inputs  # noqa: E402
+except ImportError:  # deployed revision predates the 053 rename
+    from analyzer.services.reviewer_assignment import (  # noqa: E402
+        _prepare_assignment_inputs as prepare_assignment_inputs,
+    )
 from analyzer.services.reviewer_assignment_engine import (  # noqa: E402
     _normalize_login,
     _topic_labels,

--- a/scripts/probe_053_suggestions.py
+++ b/scripts/probe_053_suggestions.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python
+"""Read-only probe for design doc 053 (on-demand assignment suggestions).
+
+Answers, against live production state: *how many suggestions would this feature actually
+have to make?* — plus the funnel and the skip-reason mix that explain the number.
+
+Strictly read-only: no DB writes, no GitHub calls, no snapshot builds. It reads the latest
+cached QueueSnapshot exactly the way `analyzer.services.reviewer_load` does, reuses
+`_prepare_assignment_inputs` for the candidate pool, and drives the real engine
+(`suggest_reviewer_for_pr_with_trace`) for every (reviewer, PR) pair.
+
+Reviewer logins are pseudonymized by default (r01, r02, ... ordered by a salt-free sha256 of
+the login) so the output can be shared; pass --no-anon to keep real logins. PR numbers and
+label names are public and are kept as-is. Author logins are never emitted.
+
+Emits one JSON object on stdout between BEGIN/END markers.
+
+Usage on the dyno:
+    PYTHONPATH=$PWD/qb_site:$PWD python probe_053_suggestions.py [--no-anon] [--repo owner/name]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from collections import Counter
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "qb_site.settings.production")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.conf import settings  # noqa: E402
+
+from analyzer.models import (  # noqa: E402
+    AssignmentProposal,
+    QueueSnapshot,
+    ReviewerAssignmentApplication,
+    ReviewerAssignmentSnapshot,
+    ReviewerOptOut,
+)
+from analyzer.services.queue_rules import default_rule_set_for_repo  # noqa: E402
+from analyzer.services.reviewer_assignment import (  # noqa: E402
+    _active_proposal_rows,
+    _assignment_forbidden_labels,
+    _filter_assignment_forbidden_prs,
+    _filter_prs_without_active_assignee,
+    _filter_prs_without_active_proposal,
+    _prepare_assignment_inputs,
+    build_reviewer_catalog,
+)
+from analyzer.services.reviewer_assignment_engine import (  # noqa: E402
+    _normalize_login,
+    _topic_labels,
+    rank_prs_for_assignment,
+    suggest_reviewer_for_pr_with_trace,
+)
+from analyzer.services.reviewer_load import build_reviewer_loads  # noqa: E402
+from core.models import Repository, ReviewerPreference  # noqa: E402
+from core.services.topic_labels import topic_label_matcher_for_repo  # noqa: E402
+
+MARK_BEGIN = "===QB-PROBE-053-JSON-BEGIN==="
+MARK_END = "===QB-PROBE-053-JSON-END==="
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def hist(values) -> dict:
+    """Counter as a plain dict with string keys, sorted numerically where possible."""
+    counter = Counter(values)
+    try:
+        keys = sorted(counter, key=lambda k: (k is None, k))
+    except TypeError:
+        keys = sorted(counter, key=str)
+    return {str(k): counter[k] for k in keys}
+
+
+def buckets(values) -> dict:
+    """0 / 1 / 2 / 3 / 4-5 / 6-10 / 11-25 / 26+ bucketing for suggestion counts."""
+    out = Counter()
+    for v in values:
+        if v <= 3:
+            out[str(v)] += 1
+        elif v <= 5:
+            out["4-5"] += 1
+        elif v <= 10:
+            out["6-10"] += 1
+        elif v <= 25:
+            out["11-25"] += 1
+        else:
+            out["26+"] += 1
+    order = ["0", "1", "2", "3", "4-5", "6-10", "11-25", "26+"]
+    return {k: out[k] for k in order if out[k]}
+
+
+def quantiles(values) -> dict:
+    vals = sorted(values)
+    if not vals:
+        return {}
+
+    def q(p: float):
+        idx = min(len(vals) - 1, max(0, int(round(p * (len(vals) - 1)))))
+        return vals[idx]
+
+    return {
+        "n": len(vals),
+        "min": vals[0],
+        "p25": q(0.25),
+        "median": q(0.5),
+        "p75": q(0.75),
+        "p90": q(0.9),
+        "max": vals[-1],
+        "mean": round(sum(vals) / len(vals), 2),
+    }
+
+
+class Anonymizer:
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+        self._map: dict[str, str] = {}
+
+    def seed(self, logins) -> None:
+        ordered = sorted({_normalize_login(x) for x in logins if x}, key=lambda s: hashlib.sha256(s.encode()).hexdigest())
+        for i, login in enumerate(ordered, start=1):
+            self._map[login] = f"r{i:02d}"
+
+    def __call__(self, login: str | None) -> str:
+        norm = _normalize_login(login)
+        if not self.enabled:
+            return norm
+        return self._map.get(norm, "r??")
+
+
+def classify(
+    *,
+    pr_entry: dict,
+    me,
+    others,
+    excluded_for_pr: set[str],
+    assignments,
+    matcher,
+    respect_availability: bool,
+) -> str:
+    """Re-derive the design-doc-053 skip tally for one (reviewer, PR) pair.
+
+    Mirrors `_reviewer_candidate_state` step for step and in its order, so the reason names map
+    onto the table in the design doc. Returns "eligible" when the reviewer would be offered the PR.
+    """
+    labels_lower = [lab.lower() for lab in _topic_labels(pr_entry, matcher)]
+    if not labels_lower:
+        return "no_topic_label"
+
+    author_norm = _normalize_login(pr_entry.get("author") or "")
+    my_login = _normalize_login(me.github_login)
+    if author_norm == my_login:
+        return "authored"
+    if author_norm in me.conflict_of_interest_lower:
+        return "conflict_of_interest"
+
+    my_match = [lab for lab in labels_lower if lab in me.preferred_labels_lower]
+    if not my_match:
+        return "no_area_match"
+
+    # max_score contest, over every reviewer the engine would consider "matching" for this PR
+    # (conflict-of-interest filtered, availability NOT filtered — same as the engine).
+    max_score = len(my_match)
+    for rev in others:
+        if author_norm in {rev.github_login.lower(), *rev.conflict_of_interest_lower}:
+            continue
+        score = sum(1 for lab in labels_lower if lab in rev.preferred_labels_lower)
+        if score > max_score:
+            max_score = score
+    if max_score > 1 and len(my_match) < max_score:
+        return "outranked"
+
+    if my_login in excluded_for_pr:
+        return "excluded"
+
+    current_weight = float(assignments.get(me.github_login, ([], 0.0, 0))[1])
+    if me.maximum_capacity - current_weight <= 0:
+        return "at_capacity"
+
+    if respect_availability:
+        if not me.auto_assign:
+            return "auto_assign_off"
+        if me.temporary_break:
+            return "away"
+
+    return "eligible"
+
+
+def run_pass(
+    *,
+    label: str,
+    reviewers,
+    profile_for,
+    ranked_prs,
+    all_prs,
+    excluded_by_pr,
+    assignments,
+    matcher,
+    respect_availability: bool,
+    limit_probe: int,
+    verify_against_engine: bool,
+    anon: Anonymizer,
+) -> dict:
+    """One what-if pass over every reviewer.
+
+    `profile_for(profile)` returns the (possibly overridden) profile the engine should see for
+    that reviewer as the *requester*; every other reviewer keeps their real profile, exactly as
+    design doc 053 specifies ("replace it, in place, with a dataclasses.replace copy").
+    """
+    per_reviewer = {}
+    reason_totals = Counter()
+    mismatches = 0
+    rank_of_first_hit = []
+
+    for me_real in reviewers:
+        me = profile_for(me_real)
+        my_login = _normalize_login(me.github_login)
+        catalog = [me if _normalize_login(r.github_login) == my_login else r for r in reviewers]
+        others = [r for r in catalog if _normalize_login(r.github_login) != my_login]
+
+        reasons = Counter()
+        eligible_prs = []
+        first_hit_rank = None
+
+        for rank, pr_number in enumerate(ranked_prs):
+            pr_entry = all_prs.get(pr_number) or all_prs.get(str(pr_number)) or {}
+            excluded_for_pr = {_normalize_login(x) for x in excluded_by_pr.get(pr_number, set())}
+            reason = classify(
+                pr_entry=pr_entry,
+                me=me,
+                others=others,
+                excluded_for_pr=excluded_for_pr,
+                assignments=assignments,
+                matcher=matcher,
+                respect_availability=respect_availability,
+            )
+            reasons[reason] += 1
+            if reason == "eligible":
+                eligible_prs.append(pr_number)
+                if first_hit_rank is None:
+                    first_hit_rank = rank
+
+            if verify_against_engine:
+                _result, trace = suggest_reviewer_for_pr_with_trace(
+                    pr_entry=pr_entry,
+                    reviewers=catalog,
+                    assignment_stats=assignments,
+                    excluded_logins=excluded_by_pr.get(pr_number, set()),
+                    topic_label_matcher=matcher,
+                )
+                in_available = my_login in {_normalize_login(x) for x in trace.get("available", [])}
+                if in_available != (reason == "eligible"):
+                    mismatches += 1
+
+        if first_hit_rank is not None:
+            rank_of_first_hit.append(first_hit_rank)
+        reason_totals.update(reasons)
+        per_reviewer[anon(me.github_login)] = {
+            "eligible": len(eligible_prs),
+            "would_show": min(len(eligible_prs), limit_probe),
+            "top_prs": eligible_prs[:limit_probe],
+            "reasons": dict(reasons),
+        }
+
+    counts = [v["eligible"] for v in per_reviewer.values()]
+    return {
+        "pass": label,
+        "reviewers": len(per_reviewer),
+        "eligible_counts": quantiles(counts),
+        "eligible_buckets": buckets(counts),
+        "reviewers_with_zero": sum(1 for c in counts if c == 0),
+        "reviewers_with_at_least_limit": sum(1 for c in counts if c >= limit_probe),
+        "reason_totals": dict(reason_totals.most_common()),
+        "rank_of_first_eligible_pr": quantiles(rank_of_first_hit),
+        "engine_mismatches": mismatches if verify_against_engine else None,
+        "per_reviewer": per_reviewer,
+    }
+
+
+def probe_repo(repository: Repository, *, anon: Anonymizer, limit_probe: int, now: datetime) -> dict:
+    out: dict = {"repository": f"{repository.owner}/{repository.name}", "repository_id": repository.id}
+
+    rule_set = default_rule_set_for_repo(repository)
+    cache_key = str(rule_set.id) if rule_set else "default"
+    snap = QueueSnapshot.objects.filter(repository=repository, cache_key=cache_key).order_by("-generated_at").first()
+    if snap is None or not snap.payload:
+        out["status"] = "no_snapshot"
+        return out
+
+    t0 = time.perf_counter()
+    payload = snap.payload
+    payload_read_seconds = round(time.perf_counter() - t0, 3)
+    payload_bytes = len(json.dumps(payload, separators=(",", ":")))
+
+    out["snapshot"] = {
+        "cache_key": cache_key,
+        "generated_at": snap.generated_at.isoformat(),
+        "age_hours": round((now - snap.generated_at).total_seconds() / 3600, 2),
+        "pr_count": snap.pr_count,
+        "queue_count": snap.queue_count,
+        "payload_bytes": payload_bytes,
+        "payload_mb": round(payload_bytes / 1_000_000, 2),
+        "payload_read_seconds": payload_read_seconds,
+    }
+
+    matcher = topic_label_matcher_for_repo(repository)
+    all_prs = payload.get("prs", {})
+    queue_prs = list(payload.get("lists", {}).get("dashboards", {}).get("Queue", []))
+
+    # --- funnel: reproduce _prepare_assignment_inputs step by step for the counts -------------
+    reviewers = build_reviewer_catalog(repository, now=now)
+    after_assignee = _filter_prs_without_active_assignee(queue_prs, all_prs=all_prs, reviewers=reviewers)
+    forbidden = _assignment_forbidden_labels(repository, rule_set=rule_set)
+    after_forbidden = _filter_assignment_forbidden_prs(after_assignee, all_prs=all_prs, forbidden_labels=forbidden)
+    active_rows = _active_proposal_rows(repository)
+    after_proposal = _filter_prs_without_active_proposal(after_forbidden, prs_with_active_proposal={n for n, _ in active_rows})
+
+    inputs = _prepare_assignment_inputs(repository, payload=payload, now=now, rule_set=rule_set)
+    pool = inputs.assignable_queue_prs
+
+    no_topic_label = sum(1 for n in pool if not _topic_labels(all_prs.get(n) or all_prs.get(str(n)) or {}, matcher))
+    out["funnel"] = {
+        "queue_prs": len(queue_prs),
+        "after_active_assignee_filter": len(after_assignee),
+        "dropped_has_active_assignee": len(queue_prs) - len(after_assignee),
+        "after_forbidden_label_filter": len(after_forbidden),
+        "dropped_forbidden_label": len(after_assignee) - len(after_forbidden),
+        "forbidden_labels": sorted(forbidden),
+        "after_active_proposal_filter": len(after_proposal),
+        "dropped_active_proposal": len(after_forbidden) - len(after_proposal),
+        "assignable_pool": len(pool),
+        "pool_without_topic_label": no_topic_label,
+        "pool_with_topic_label": len(pool) - no_topic_label,
+        "prs_with_per_pr_exclusions": sum(1 for n in pool if inputs.excluded_by_pr.get(n)),
+        "total_per_pr_exclusions": sum(len(v) for v in inputs.excluded_by_pr.values()),
+    }
+
+    # --- reviewer population ------------------------------------------------------------------
+    loads = build_reviewer_loads(repository, snapshot_payload=payload, now=now)
+    prefs = list(ReviewerPreference.objects.filter(repository=repository).select_related("user"))
+    anon.seed([r.github_login for r in reviewers])
+
+    out["reviewers"] = {
+        "preference_rows": len(prefs),
+        "with_github_login": len(reviewers),
+        "auto_assign_off": sum(1 for r in reviewers if not r.auto_assign),
+        "away_now": sum(1 for r in reviewers if r.temporary_break),
+        "unavailable_either_way": sum(1 for r in reviewers if not r.auto_assign or r.temporary_break),
+        "no_preferred_labels": sum(1 for r in reviewers if not r.preferred_labels_lower),
+        "with_conflicts": sum(1 for r in reviewers if r.conflict_of_interest_lower),
+        "acceptance_mode": hist(p.assignment_acceptance for p in prefs),
+        "zulip_linked": sum(1 for p in prefs if getattr(p.user, "zulip_user_id", None) is not None),
+        "preferred_label_count": quantiles([len(r.preferred_labels_lower) for r in reviewers]),
+        "maximum_capacity": quantiles([r.maximum_capacity for r in reviewers]),
+        "current_load": quantiles([round(v.current_load, 2) for v in loads.values()]),
+        "at_capacity": sum(1 for v in loads.values() if v.at_capacity),
+        "remaining_capacity": quantiles([round(v.remaining, 2) for v in loads.values()]),
+    }
+
+    # --- label supply/demand ------------------------------------------------------------------
+    pool_label_counts = Counter()
+    for n in pool:
+        for lab in _topic_labels(all_prs.get(n) or all_prs.get(str(n)) or {}, matcher):
+            pool_label_counts[lab.lower()] += 1
+    reviewers_per_label = Counter()
+    for r in reviewers:
+        for lab in r.preferred_labels_lower:
+            reviewers_per_label[lab] += 1
+    out["labels"] = {
+        "distinct_topic_labels_in_pool": len(pool_label_counts),
+        "topic_labels_per_pool_pr": quantiles(
+            [len(_topic_labels(all_prs.get(n) or all_prs.get(str(n)) or {}, matcher)) for n in pool]
+        ),
+        "pool_prs_by_label": dict(pool_label_counts.most_common(40)),
+        "reviewers_by_label": {lab: reviewers_per_label.get(lab, 0) for lab, _ in pool_label_counts.most_common(40)},
+        "pool_labels_with_no_interested_reviewer": sorted(lab for lab in pool_label_counts if not reviewers_per_label.get(lab)),
+    }
+
+    # --- rank the pool once, exactly as the design says the service would ---------------------
+    t0 = time.perf_counter()
+    ranked_prs, _ranking_trace = rank_prs_for_assignment(
+        prs_to_assign=pool,
+        all_prs=all_prs,
+        reviewers=inputs.reviewers,
+        assignment_stats=inputs.assignments,
+        excluded_by_pr=inputs.excluded_by_pr,
+        topic_label_matcher=matcher,
+    )
+    rank_seconds = round(time.perf_counter() - t0, 3)
+
+    all_pool_labels = set(pool_label_counts)
+
+    passes = []
+    common = dict(
+        reviewers=inputs.reviewers,
+        ranked_prs=ranked_prs,
+        all_prs=all_prs,
+        excluded_by_pr=inputs.excluded_by_pr,
+        assignments=inputs.assignments,
+        matcher=matcher,
+        limit_probe=limit_probe,
+        anon=anon,
+    )
+
+    # A. baseline: the reviewer exactly as they are (what the nightly engine sees)
+    passes.append(
+        run_pass(
+            label="A_as_is",
+            profile_for=lambda p: p,
+            respect_availability=True,
+            verify_against_engine=True,
+            **common,
+        )
+    )
+    # B. design 053 default: availability overridden, own labels, own capacity
+    passes.append(
+        run_pass(
+            label="B_availability_override",
+            profile_for=lambda p: replace(p, auto_assign=True, temporary_break=False),
+            respect_availability=False,
+            verify_against_engine=False,
+            **common,
+        )
+    )
+    # C. + allow_over_capacity
+    passes.append(
+        run_pass(
+            label="C_over_capacity",
+            profile_for=lambda p: replace(p, auto_assign=True, temporary_break=False, maximum_capacity=10**6),
+            respect_availability=False,
+            verify_against_engine=False,
+            **common,
+        )
+    )
+    # D. + broad label override ("give me anything"): every topic label present in the pool
+    passes.append(
+        run_pass(
+            label="D_all_labels_override",
+            profile_for=lambda p: replace(
+                p,
+                auto_assign=True,
+                temporary_break=False,
+                preferred_labels=sorted(all_pool_labels),
+                preferred_labels_lower=set(all_pool_labels),
+            ),
+            respect_availability=False,
+            verify_against_engine=False,
+            **common,
+        )
+    )
+    out["passes"] = passes
+
+    # --- what the nightly run would place, for comparison -------------------------------------
+    ras = ReviewerAssignmentSnapshot.objects.filter(repository=repository, cache_key=cache_key).order_by("-generated_at").first()
+    if ras:
+        auto = (ras.payload or {}).get("automatic_assignments", {}) or {}
+        per_login = Counter(_normalize_login(v) for v in auto.values())
+        out["nightly"] = {
+            "generated_at": ras.generated_at.isoformat(),
+            "age_hours": round((now - ras.generated_at).total_seconds() / 3600, 2),
+            "assignment_count": ras.assignment_count,
+            "pool_size_now": len(pool),
+            "unplaceable_now": len(pool) - len(auto),
+            "apply_cap_per_repo": int(getattr(settings, "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_MAX_PER_REPO", 25)),
+            "over_cap_backlog": max(0, len(auto) - int(getattr(settings, "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_MAX_PER_REPO", 25))),
+            "prs_per_reviewer": quantiles(list(per_login.values())),
+            "reviewers_receiving_any": len(per_login),
+        }
+    else:
+        out["nightly"] = {"status": "no_snapshot"}
+
+    # --- proposal / application history: is push-based assignment landing? --------------------
+    props = AssignmentProposal.objects.filter(repository=repository)
+    since_30 = now - timedelta(days=30)
+    out["history"] = {
+        "proposals_all_time": hist(props.values_list("state", flat=True)),
+        "proposals_last_30d": hist(props.filter(created_at__gte=since_30).values_list("state", flat=True)),
+        "proposals_active_now": props.filter(state=AssignmentProposal.STATE_PROPOSED).count(),
+        "applications_all_time": hist(
+            ReviewerAssignmentApplication.objects.filter(repository=repository).values_list("status", flat=True)
+        ),
+        "applications_last_30d": hist(
+            ReviewerAssignmentApplication.objects.filter(repository=repository, created_at__gte=since_30).values_list(
+                "status", flat=True
+            )
+        ),
+        "opt_outs_active": ReviewerOptOut.objects.filter(repository=repository, active=True).count(),
+        "opt_outs_all_time": ReviewerOptOut.objects.filter(repository=repository).count(),
+    }
+
+    # --- cost of one interactive request -------------------------------------------------------
+    if reviewers and pool:
+        probe_reviewer = reviewers[0]
+        me = replace(probe_reviewer, auto_assign=True, temporary_break=False)
+        catalog = [me if _normalize_login(r.github_login) == _normalize_login(me.github_login) else r for r in inputs.reviewers]
+        t0 = time.perf_counter()
+        for n in ranked_prs:
+            suggest_reviewer_for_pr_with_trace(
+                pr_entry=all_prs.get(n) or all_prs.get(str(n)) or {},
+                reviewers=catalog,
+                assignment_stats=inputs.assignments,
+                excluded_logins=inputs.excluded_by_pr.get(n, set()),
+                topic_label_matcher=matcher,
+            )
+        walk_seconds = round(time.perf_counter() - t0, 3)
+        out["cost"] = {
+            "payload_read_seconds": payload_read_seconds,
+            "rank_seconds": rank_seconds,
+            "full_walk_seconds": walk_seconds,
+            "estimated_request_seconds": round(payload_read_seconds + rank_seconds + walk_seconds, 3),
+            "note": "walk is the worst case (no early stop at limit); the service stops at `limit` hits",
+        }
+
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-anon", action="store_true", help="emit real reviewer logins")
+    parser.add_argument("--repo", default=None, help="restrict to owner/name")
+    parser.add_argument("--limit", type=int, default=10, help="the ANALYZER_ASSIGNMENT_SUGGESTIONS_LIMIT to probe")
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc)
+    anon = Anonymizer(enabled=not args.no_anon)
+
+    repos = Repository.objects.all().order_by("id")
+    if args.repo:
+        owner, _, name = args.repo.partition("/")
+        repos = repos.filter(owner=owner, name=name)
+
+    result = {
+        "probe": "design-doc-053-on-demand-assignment-suggestions",
+        "generated_at": now.isoformat(),
+        "anonymized": anon.enabled,
+        "limit_probed": args.limit,
+        "settings": {
+            "ANALYZER_ASSIGNMENT_PROPOSALS_ENABLED": getattr(settings, "ANALYZER_ASSIGNMENT_PROPOSALS_ENABLED", None),
+            "ANALYZER_ASSIGNMENT_PROPOSALS_DRY_RUN": getattr(settings, "ANALYZER_ASSIGNMENT_PROPOSALS_DRY_RUN", None),
+            "ANALYZER_ASSIGNMENT_PROPOSALS_ASSIGN_ON_ACCEPT_ENABLED": getattr(
+                settings, "ANALYZER_ASSIGNMENT_PROPOSALS_ASSIGN_ON_ACCEPT_ENABLED", None
+            ),
+            "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_ENABLED": getattr(settings, "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_ENABLED", None),
+            "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_DRY_RUN": getattr(settings, "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_DRY_RUN", None),
+            "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_MAX_PER_REPO": getattr(
+                settings, "ANALYZER_REVIEWER_ASSIGNMENT_APPLY_MAX_PER_REPO", None
+            ),
+            "ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS": getattr(settings, "ANALYZER_ASSIGNMENT_PROPOSAL_WINDOW_DAYS", None),
+            "ANALYZER_ASSIGNMENT_PROPOSAL_PENDING_LOAD_WEIGHT": getattr(
+                settings, "ANALYZER_ASSIGNMENT_PROPOSAL_PENDING_LOAD_WEIGHT", None
+            ),
+            "ANALYZER_ASSIGNMENT_PROPOSAL_EXPIRE_COOLDOWN_DAYS": getattr(
+                settings, "ANALYZER_ASSIGNMENT_PROPOSAL_EXPIRE_COOLDOWN_DAYS", None
+            ),
+        },
+        "repositories": [],
+    }
+
+    for repo in repos:
+        if not ReviewerPreference.objects.filter(repository=repo).exists():
+            continue
+        log(f"probing {repo.owner}/{repo.name} ...")
+        try:
+            result["repositories"].append(probe_repo(repo, anon=anon, limit_probe=args.limit, now=now))
+        except Exception as exc:  # noqa: BLE001 - a probe should report, not crash the run
+            result["repositories"].append({"repository": f"{repo.owner}/{repo.name}", "error": f"{type(exc).__name__}: {exc}"})
+            log(f"  failed: {type(exc).__name__}: {exc}")
+
+    print(MARK_BEGIN)
+    print(json.dumps(result, indent=2, default=str))
+    print(MARK_END)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_053_suggestions.py
+++ b/scripts/probe_053_suggestions.py
@@ -6,7 +6,7 @@ have to make?* — plus the funnel and the skip-reason mix that explain the numb
 
 Strictly read-only: no DB writes, no GitHub calls, no snapshot builds. It reads the latest
 cached QueueSnapshot exactly the way `analyzer.services.reviewer_load` does, reuses
-`_prepare_assignment_inputs` for the candidate pool, and drives the real engine
+`prepare_assignment_inputs` for the candidate pool, and drives the real engine
 (`suggest_reviewer_for_pr_with_trace`) for every (reviewer, PR) pair.
 
 Reviewer logins are pseudonymized by default (r01, r02, ... ordered by a salt-free sha256 of
@@ -53,7 +53,7 @@ from analyzer.services.reviewer_assignment import (  # noqa: E402
     _filter_assignment_forbidden_prs,
     _filter_prs_without_active_assignee,
     _filter_prs_without_active_proposal,
-    _prepare_assignment_inputs,
+    prepare_assignment_inputs,
     build_reviewer_catalog,
 )
 from analyzer.services.reviewer_assignment_engine import (  # noqa: E402
@@ -319,7 +319,7 @@ def probe_repo(repository: Repository, *, anon: Anonymizer, limit_probe: int, no
     all_prs = payload.get("prs", {})
     queue_prs = list(payload.get("lists", {}).get("dashboards", {}).get("Queue", []))
 
-    # --- funnel: reproduce _prepare_assignment_inputs step by step for the counts -------------
+    # --- funnel: reproduce prepare_assignment_inputs step by step for the counts -------------
     reviewers = build_reviewer_catalog(repository, now=now)
     after_assignee = _filter_prs_without_active_assignee(queue_prs, all_prs=all_prs, reviewers=reviewers)
     forbidden = _assignment_forbidden_labels(repository, rule_set=rule_set)
@@ -327,7 +327,7 @@ def probe_repo(repository: Repository, *, anon: Anonymizer, limit_probe: int, no
     active_rows = _active_proposal_rows(repository)
     after_proposal = _filter_prs_without_active_proposal(after_forbidden, prs_with_active_proposal={n for n, _ in active_rows})
 
-    inputs = _prepare_assignment_inputs(repository, payload=payload, now=now, rule_set=rule_set)
+    inputs = prepare_assignment_inputs(repository, payload=payload, now=now, rule_set=rule_set)
     pool = inputs.assignable_queue_prs
 
     no_topic_label = sum(1 for n in pool if not _topic_labels(all_prs.get(n) or all_prs.get(str(n)) or {}, matcher))


### PR DESCRIPTION
Add a page to the console and a zulip command (`suggest-prs`) which return up to 10 suggestions of PRs to review. A set of labels can be specified to scope the suggestions differently from the default. Reviewers then can assign themselves to those PRs manually.